### PR TITLE
Problem: mdbook use_service_worker script is not portable

### DIFF
--- a/examples/use_service_worker/Trunk.toml
+++ b/examples/use_service_worker/Trunk.toml
@@ -4,4 +4,4 @@ public_url = "/demo/"
 [[hooks]]
 stage = "post_build"
 command = "bash"
-command_arguments = ["-c", "./post_build.sh"]
+command_arguments = ["post_build.sh"]

--- a/examples/use_service_worker/post_build.sh
+++ b/examples/use_service_worker/post_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 appName="use_service_worker"


### PR DESCRIPTION
I've been having trouble building the mdbook with `python3 post_build.py`. This was failing for two reasons.

The first was that bash was being called with a command string "./post_build.sh" for the use_service_worker. I've changed this to rely on calling the file directly by removing -c option. The second was that the bash script was relying on `#! /bin/bash`. I'm on NixOS which doesn't have a /bin/bash.

So this PR should make the mdbook build scripts more portable.