### PR TITLE
Use previous Trunk version in CI and apply clippy suggestions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install mdbook II
         run: |
           cargo binstall -y mdbook-cmdrun
-          cargo binstall -y trunk
+          cargo binstall -y trunk@0.17.5
           rustup target add wasm32-unknown-unknown
       - name: Setup Pages
         id: pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install mdbook II
         run: |
           cargo binstall -y mdbook-cmdrun
-          cargo binstall -y trunk
+          cargo binstall -y trunk@0.17.5
           rustup target add wasm32-unknown-unknown
       - name: Setup Pages
         id: pages

--- a/examples/use_storage/src/main.rs
+++ b/examples/use_storage/src/main.rs
@@ -1,6 +1,7 @@
 use leptos::*;
 use leptos_use::docs::{demo_or_body, Note};
-use leptos_use::storage::{use_local_storage, JsonCodec};
+use leptos_use::storage::use_local_storage;
+use leptos_use::utils::JsonCodec;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/src/use_broadcast_channel.rs
+++ b/src/use_broadcast_channel.rs
@@ -103,8 +103,6 @@ where
     };
 
     let close = {
-        let channel = channel.clone();
-
         move || {
             if let Some(channel) = channel.get_untracked() {
                 channel.close();
@@ -153,7 +151,7 @@ where
         close();
     });
 
-    return UseBroadcastChannelReturn {
+    UseBroadcastChannelReturn {
         is_supported,
         channel: channel.into(),
         message: message.into(),
@@ -161,7 +159,7 @@ where
         close,
         error: error.into(),
         is_closed: is_closed.into(),
-    };
+    }
 }
 
 /// Return type of [`use_broadcast_channel`].


### PR DESCRIPTION
- Install Trunk v0.17.5, next versions are breaking the build because they are not generating the starting `<head>` element on examples.
- Apply clippy suggestions.