### PR TITLE
Prefer signals over memos with first unused argument when possible

### DIFF
--- a/src/core/element_maybe_signal.rs
+++ b/src/core/element_maybe_signal.rs
@@ -208,8 +208,7 @@ macro_rules! impl_from_signal_string {
                     Self::Dynamic(Signal::derive(|| None))
                 } else {
                     Self::Dynamic(
-                        create_memo(move |_| document().query_selector(&signal.get()).unwrap_or_default())
-                            .into(),
+                        Signal::derive(move || document().query_selector(&signal.get()).unwrap_or_default()),
                     )
                 }}
             }

--- a/src/core/elements_maybe_signal.rs
+++ b/src/core/elements_maybe_signal.rs
@@ -216,7 +216,7 @@ macro_rules! impl_from_signal_string {
             fn from(signal: $ty) -> Self {
                 cfg_if! { if #[cfg(feature = "ssr")] {
                     Self::Dynamic(
-                        create_memo(move |_| {
+                        Signal::derive(move || {
                             if let Ok(node_list) = document().query_selector_all(&signal.get()) {
                                 let mut list = Vec::with_capacity(node_list.length() as usize);
                                 for i in 0..node_list.length() {
@@ -227,8 +227,7 @@ macro_rules! impl_from_signal_string {
                             } else {
                                 vec![]
                             }
-                        })
-                        .into(),
+                        }),
                     )
                 } else {
                     let _ = signal;

--- a/src/math/shared.rs
+++ b/src/math/shared.rs
@@ -13,7 +13,7 @@ macro_rules! use_partial_cmp {
         {
             let container = container.into();
 
-            create_memo(move |_| {
+            Signal::derive(move || {
                 container.with(|container| {
                     if container.into_iter().count() == 0 {
                         return None;
@@ -34,7 +34,6 @@ macro_rules! use_partial_cmp {
                         .cloned()
                 })
             })
-            .into()
         }
     };
 }

--- a/src/use_breakpoints.rs
+++ b/src/use_breakpoints.rs
@@ -264,14 +264,13 @@ impl<K: Eq + Hash + Debug + Clone> UseBreakpointsReturn<K> {
 
         let signals: Vec<_> = keys.iter().map(ge.clone()).collect();
 
-        create_memo(move |_| {
+        Signal::derive(move || {
             keys.iter()
                 .cloned()
                 .zip(signals.iter().cloned())
                 .filter_map(|(key, signal)| signal.get().then_some(key))
                 .collect::<Vec<_>>()
         })
-        .into()
     }
 }
 

--- a/src/use_cycle_list.rs
+++ b/src/use_cycle_list.rs
@@ -86,7 +86,7 @@ where
     let index = {
         let list = list.clone();
 
-        create_memo(move |_| {
+        Signal::derive(move || {
             list.with(|list| {
                 let index = get_position(&state.get(), list);
 
@@ -161,7 +161,7 @@ where
     UseCycleListReturn {
         state,
         set_state,
-        index: index.into(),
+        index,
         set_index: set,
         next,
         prev,

--- a/src/use_infinite_scroll.rs
+++ b/src/use_infinite_scroll.rs
@@ -108,7 +108,7 @@ where
     let (is_loading, set_loading) = create_signal(false);
 
     let el = el.into();
-    let observed_element = create_memo(move |_| {
+    let observed_element = Signal::derive(move || {
         let el = el.get();
 
         el.map(|el| {

--- a/src/use_sorted.rs
+++ b/src/use_sorted.rs
@@ -81,12 +81,11 @@ where
 {
     let iterable = iterable.into();
 
-    create_memo(move |_| {
+    Signal::derive(move || {
         let mut iterable = iterable.get();
         iterable.sort();
         iterable
     })
-    .into()
 }
 
 /// Version of [`use_sorted`] with a compare function.
@@ -98,12 +97,11 @@ where
 {
     let iterable = iterable.into();
 
-    create_memo(move |_| {
+    Signal::derive(move || {
         let mut iterable = iterable.get();
         iterable.sort_by(cmp_fn.clone());
         iterable
     })
-    .into()
 }
 
 /// Version of [`use_sorted`] by key.
@@ -116,10 +114,9 @@ where
 {
     let iterable = iterable.into();
 
-    create_memo(move |_| {
+    Signal::derive(move || {
         let mut iterable = iterable.get();
         iterable.sort_by_key(key_fn.clone());
         iterable
     })
-    .into()
 }


### PR DESCRIPTION
Use [`impl Fn() -> T + 'static`](https://docs.rs/leptos/latest/leptos/struct.Signal.html#method.derive) instead of [`impl Fn(Option<&T>) -> T + 'static`](https://docs.rs/leptos/latest/leptos/fn.create_memo.html) when possible.