### PR TITLE
Fix `.demo-source` docs links

### DIFF
--- a/docs/book/src/demo.css
+++ b/docs/book/src/demo.css
@@ -8,6 +8,7 @@
     top: 8px;
     font-size: 12px;
     font-weight: 500;
+    z-index: 50;
 }
 
 .demo-container > a.demo-source > i.fa {

--- a/src/use_clipboard.rs
+++ b/src/use_clipboard.rs
@@ -25,7 +25,7 @@ use leptos::*;
 /// #
 /// # #[component]
 /// # fn Demo() -> impl IntoView {
-/// let UsClipboardReturn { is_supported, text, copied, copy } = use_clipboard();
+/// let UseClipboardReturn { is_supported, text, copied, copy } = use_clipboard();
 ///
 /// view! {
 ///     <Show


### PR DESCRIPTION
The "Source" button of the clipboard demo can't be easily clicked at https://leptos-use.rs/browser/use_clipboard.html

