### PR TITLE
Fix SSR detection from an url query parameter for `use_color_mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fix 🍕
+
+- Fixed SSR detection from an url query parameter for `use_color_mode`.
+
 ## [0.10.4] - 2024-03-05
 
 ### New Functions 🚀

--- a/src/core/url.rs
+++ b/src/core/url.rs
@@ -1,5 +1,6 @@
 use leptos::window;
 
+#[cfg_attr(feature = "ssr", allow(dead_code))]
 fn get() -> web_sys::Url {
     web_sys::Url::new(
         &window()
@@ -11,10 +12,16 @@ fn get() -> web_sys::Url {
 }
 
 pub mod params {
-    use super::get as current_url;
+    use cfg_if::cfg_if;
 
     /// Get a URL param value from the URL of the browser
     pub fn get(k: &str) -> Option<String> {
-        current_url().search_params().get(k)
+        cfg_if! { if #[cfg(feature = "ssr")] {
+            _ = k;
+            None
+        } else {
+            use super::get as current_url;
+            current_url().search_params().get(k)
+        }}
     }
 }


### PR DESCRIPTION
I missed that on #79. Currently panics when compiling if `initial_value_from_url_param` is `true` on the server.