### PR TITLE
Fix document.set_cookie usage

### DIFF
--- a/examples/use_cookie/src/main.rs
+++ b/examples/use_cookie/src/main.rs
@@ -6,22 +6,33 @@ use rand::prelude::*;
 
 #[component]
 fn Demo() -> impl IntoView {
-    let (counter, set_counter) = use_cookie::<u32, FromToStringCodec>("counter");
+    let (counter_a, set_counter_a) = use_cookie::<u32, FromToStringCodec>("counter_a");
+    let (counter_b, set_counter_b) = use_cookie::<u32, FromToStringCodec>("counter_b");
 
-    let reset = move || set_counter(Some(random()));
+    let reset_a = move || set_counter_a(Some(random()));
+    let reset_b = move || set_counter_b(Some(random()));
 
-    if counter().is_none() {
-        reset();
+    if counter_a().is_none() {
+        reset_a();
+    }
+    if counter_b().is_none() {
+        reset_b();
     }
 
-    let increase = move || {
-        set_counter(counter().map(|c| c + 1));
+    let increase_a = move || {
+        set_counter_a(counter_a().map(|c| c + 1));
+    };
+    let increase_b = move || {
+        set_counter_b(counter_b().map(|c| c + 1));
     };
 
     view! {
-        <p>Counter: {move || counter().map(|c| c.to_string()).unwrap_or("—".to_string())}</p>
-        <button on:click=move |_| reset()>Reset</button>
-        <button on:click=move |_| increase()>+</button>
+        <p>Counter A: {move || counter_a().map(|c| c.to_string()).unwrap_or("—".to_string())}</p>
+        <button on:click=move |_| reset_a()>Reset</button>
+        <button on:click=move |_| increase_a()>+</button>
+        <p>Counter B: {move || counter_b().map(|c| c.to_string()).unwrap_or("—".to_string())}</p>
+        <button on:click=move |_| reset_b()>Reset</button>
+        <button on:click=move |_| increase_b()>+</button>
     }
 }
 


### PR DESCRIPTION
Setting `document.cookie` only supports [setting a single cookie at a time](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie). Currently `use_cookie` will try to set multiple cookies by serializing the whole cookie jar. This PR fixes setting and deleting cookies from the client, and adds a second counter to the `use_cookie` example. This example is broken with the current `use_cookie` implementation and works correctly in this branch.

Unfortunately `cookie` uses `time` so `jar.remove` doesn't work in WASM, which makes the implementation a bit awkward (have to first add the cookie with value="" and expires=0, and then afterward call `jar.force_remove`)