### PR TITLE
Progress towards Leptos 0.7.0-alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,15 @@ http1 = { version = "1", optional = true, package = "http" }
 http0_2 = { version = "0.2", optional = true, package = "http" }
 js-sys = "0.3"
 lazy_static = "1"
-leptos = { version = "0.7.0-preview2", path = "../leptos/leptos" }
-leptos_axum = { version = "0.7.0-preview2", optional = true }
+leptos = { version = "0.7.0-alpha" }
+leptos_axum = { version = "0.7.0-alpha", optional = true }
 leptos_actix = { version = "0.6", optional = true }
 leptos-spin = { version = "0.2", optional = true }
 num = { version = "0.4", optional = true }
 paste = "1"
 prost = { version = "0.12", optional = true }
 rmp-serde = { version = "1.1", optional = true }
+send_wrapper = "0.6.0"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "1"
@@ -133,7 +134,7 @@ features = [
 
 [dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-leptos_meta = "0.7.0-preview2"
+leptos_meta = "0.7.0-alpha"
 rand = "0.8"
 
 [features]

--- a/src/core/element_maybe_signal.rs
+++ b/src/core/element_maybe_signal.rs
@@ -44,30 +44,16 @@ where
     }
 }
 
-impl<T, E> SignalGet for ElementMaybeSignal<T, E>
+impl<T, E> DefinedAt for ElementMaybeSignal<T, E>
 where
     T: Into<E> + Clone + 'static,
 {
-    type Value = Option<T>;
-
-    fn get(&self) -> Option<T> {
-        match self {
-            Self::Static(t) => t.clone(),
-            Self::Dynamic(s) => s.get(),
-            _ => unreachable!(),
-        }
-    }
-
-    fn try_get(&self) -> Option<Option<T>> {
-        match self {
-            Self::Static(t) => Some(t.clone()),
-            Self::Dynamic(s) => s.try_get(),
-            _ => unreachable!(),
-        }
+    fn defined_at(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
     }
 }
 
-impl<T, E> SignalWith for ElementMaybeSignal<T, E>
+impl<T, E> With for ElementMaybeSignal<T, E>
 where
     T: Into<E> + Clone + 'static,
 {
@@ -90,7 +76,7 @@ where
     }
 }
 
-impl<T, E> SignalWithUntracked for ElementMaybeSignal<T, E>
+impl<T, E> WithUntracked for ElementMaybeSignal<T, E>
 where
     T: Into<E> + Clone + 'static,
 {
@@ -108,29 +94,6 @@ where
         match self {
             Self::Static(t) => Some(f(t)),
             Self::Dynamic(s) => s.try_with_untracked(f),
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl<T, E> SignalGetUntracked for ElementMaybeSignal<T, E>
-where
-    T: Into<E> + Clone + 'static,
-{
-    type Value = Option<T>;
-
-    fn get_untracked(&self) -> Option<T> {
-        match self {
-            Self::Static(t) => t.clone(),
-            Self::Dynamic(s) => s.get_untracked(),
-            _ => unreachable!(),
-        }
-    }
-
-    fn try_get_untracked(&self) -> Option<Option<T>> {
-        match self {
-            Self::Static(t) => Some(t.clone()),
-            Self::Dynamic(s) => s.try_get_untracked(),
             _ => unreachable!(),
         }
     }

--- a/src/core/elements_maybe_signal.rs
+++ b/src/core/elements_maybe_signal.rs
@@ -45,30 +45,16 @@ where
     }
 }
 
-impl<T, E> SignalGet for ElementsMaybeSignal<T, E>
+impl<T, E> DefinedAt for ElementsMaybeSignal<T, E>
 where
     T: Into<E> + Clone + 'static,
 {
-    type Value = Vec<Option<T>>;
-
-    fn get(&self) -> Vec<Option<T>> {
-        match self {
-            Self::Static(v) => v.clone(),
-            Self::Dynamic(s) => s.get(),
-            Self::_Phantom(_) => unreachable!(),
-        }
-    }
-
-    fn try_get(&self) -> Option<Vec<Option<T>>> {
-        match self {
-            Self::Static(v) => Some(v.clone()),
-            Self::Dynamic(s) => s.try_get(),
-            Self::_Phantom(_) => unreachable!(),
-        }
+    fn defined_at(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
     }
 }
 
-impl<T, E> SignalWith for ElementsMaybeSignal<T, E>
+impl<T, E> With for ElementsMaybeSignal<T, E>
 where
     T: Into<E> + Clone + 'static,
 {
@@ -91,7 +77,7 @@ where
     }
 }
 
-impl<T, E> SignalWithUntracked for ElementsMaybeSignal<T, E>
+impl<T, E> WithUntracked for ElementsMaybeSignal<T, E>
 where
     T: Into<E> + Clone + 'static,
 {
@@ -109,29 +95,6 @@ where
         match self {
             Self::Static(t) => Some(f(t)),
             Self::Dynamic(s) => s.try_with_untracked(f),
-            Self::_Phantom(_) => unreachable!(),
-        }
-    }
-}
-
-impl<T, E> SignalGetUntracked for ElementsMaybeSignal<T, E>
-where
-    T: Into<E> + Clone + 'static,
-{
-    type Value = Vec<Option<T>>;
-
-    fn get_untracked(&self) -> Vec<Option<T>> {
-        match self {
-            Self::Static(t) => t.clone(),
-            Self::Dynamic(s) => s.get_untracked(),
-            Self::_Phantom(_) => unreachable!(),
-        }
-    }
-
-    fn try_get_untracked(&self) -> Option<Vec<Option<T>>> {
-        match self {
-            Self::Static(t) => Some(t.clone()),
-            Self::Dynamic(s) => s.try_get_untracked(),
             Self::_Phantom(_) => unreachable!(),
         }
     }

--- a/src/core/maybe_rw_signal.rs
+++ b/src/core/maybe_rw_signal.rs
@@ -93,7 +93,7 @@ impl<T: Clone> MaybeRwSignal<T> {
             Self::DynamicRead(s) => {
                 let (r, w) = signal(s.get_untracked());
 
-                create_effect(move |_| {
+                Effect::new(move |_| {
                     w.update(move |w| {
                         *w = s.get();
                     });

--- a/src/core/use_rw_signal.rs
+++ b/src/core/use_rw_signal.rs
@@ -37,49 +37,17 @@ impl<T> Clone for UseRwSignal<T> {
 
 impl<T> Copy for UseRwSignal<T> {}
 
-impl<T> SignalGet for UseRwSignal<T>
-where
-    T: Clone,
-{
-    type Value = T;
-
-    fn get(&self) -> T {
+impl<T> DefinedAt for UseRwSignal<T> {
+    fn defined_at(&self) -> Option<&'static std::panic::Location<'static>> {
         match self {
-            Self::Separate(s, _) => s.get(),
-            Self::Combined(s) => s.get(),
-        }
-    }
-
-    fn try_get(&self) -> Option<T> {
-        match self {
-            Self::Separate(s, _) => s.try_get(),
-            Self::Combined(s) => s.try_get(),
+            Self::Combined(s) => s.defined_at(),
+            // NOTE: is this sufficient communication?
+            Self::Separate(_, s) => s.defined_at(),
         }
     }
 }
 
-impl<T> SignalGetUntracked for UseRwSignal<T>
-where
-    T: Clone,
-{
-    type Value = T;
-
-    fn get_untracked(&self) -> T {
-        match self {
-            Self::Separate(s, _) => s.get_untracked(),
-            Self::Combined(s) => s.get_untracked(),
-        }
-    }
-
-    fn try_get_untracked(&self) -> Option<T> {
-        match self {
-            Self::Separate(s, _) => s.try_get_untracked(),
-            Self::Combined(s) => s.try_get_untracked(),
-        }
-    }
-}
-
-impl<T> SignalWith for UseRwSignal<T> {
+impl<T> With for UseRwSignal<T> {
     type Value = T;
 
     fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
@@ -97,7 +65,7 @@ impl<T> SignalWith for UseRwSignal<T> {
     }
 }
 
-impl<T> SignalWithUntracked for UseRwSignal<T> {
+impl<T> WithUntracked for UseRwSignal<T> {
     type Value = T;
 
     fn with_untracked<R>(&self, f: impl FnOnce(&T) -> R) -> R {
@@ -115,7 +83,7 @@ impl<T> SignalWithUntracked for UseRwSignal<T> {
     }
 }
 
-impl<T> SignalSet for UseRwSignal<T> {
+impl<T> Set for UseRwSignal<T> {
     type Value = T;
 
     fn set(&self, new_value: T) {
@@ -133,23 +101,7 @@ impl<T> SignalSet for UseRwSignal<T> {
     }
 }
 
-impl<T> SignalSetUntracked<T> for UseRwSignal<T> {
-    fn set_untracked(&self, new_value: T) {
-        match self {
-            Self::Separate(_, s) => s.set_untracked(new_value),
-            Self::Combined(s) => s.set_untracked(new_value),
-        }
-    }
-
-    fn try_set_untracked(&self, new_value: T) -> Option<T> {
-        match self {
-            Self::Separate(_, s) => s.try_set_untracked(new_value),
-            Self::Combined(s) => s.try_set_untracked(new_value),
-        }
-    }
-}
-
-impl<T> SignalUpdate for UseRwSignal<T> {
+impl<T> Update for UseRwSignal<T> {
     type Value = T;
 
     fn update(&self, f: impl FnOnce(&mut T)) {
@@ -163,6 +115,20 @@ impl<T> SignalUpdate for UseRwSignal<T> {
         match self {
             Self::Separate(_, s) => s.try_update(f),
             Self::Combined(s) => s.try_update(f),
+        }
+    }
+
+    fn maybe_update(&self, fun: impl FnOnce(&mut Self::Value) -> bool) {
+        match self {
+            Self::Separate(_, s) => s.maybe_update(fun),
+            Self::Combined(s) => s.maybe_update(fun),
+        }
+    }
+
+    fn try_maybe_update<U>(&self, fun: impl FnOnce(&mut Self::Value) -> (bool, U)) -> Option<U> {
+        match self {
+            Self::Separate(_, s) => s.try_maybe_update(fun),
+            Self::Combined(s) => s.try_maybe_update(fun),
         }
     }
 }

--- a/src/on_click_outside.rs
+++ b/src/on_click_outside.rs
@@ -1,7 +1,6 @@
 use crate::core::{ElementMaybeSignal, ElementsMaybeSignal};
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
-use leptos::prelude::diagnostics::SpecialNonReactiveZone;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use leptos::prelude::*;
@@ -115,6 +114,7 @@ where
 
     #[cfg(not(feature = "ssr"))]
     {
+        use leptos::prelude::diagnostics::SpecialNonReactiveZone;
         let OnClickOutsideOptions {
             ignore,
             capture,

--- a/src/storage/use_local_storage.rs
+++ b/src/storage/use_local_storage.rs
@@ -15,7 +15,7 @@ pub fn use_local_storage<T, C>(
     key: impl AsRef<str>,
 ) -> (Signal<T>, WriteSignal<T>, impl Fn() + Clone)
 where
-    T: Clone + Default + PartialEq,
+    T: Clone + Default + PartialEq + Send + Sync,
     C: StringCodec<T> + Default,
 {
     use_storage_with_options(
@@ -31,7 +31,7 @@ pub fn use_local_storage_with_options<T, C>(
     options: UseStorageOptions<T, C>,
 ) -> (Signal<T>, WriteSignal<T>, impl Fn() + Clone)
 where
-    T: Clone + PartialEq,
+    T: Clone + PartialEq + Send + Sync,
     C: StringCodec<T> + Default,
 {
     use_storage_with_options(StorageType::Local, key, options)

--- a/src/storage/use_session_storage.rs
+++ b/src/storage/use_session_storage.rs
@@ -15,7 +15,7 @@ pub fn use_session_storage<T, C>(
     key: impl AsRef<str>,
 ) -> (Signal<T>, WriteSignal<T>, impl Fn() + Clone)
 where
-    T: Clone + Default + PartialEq,
+    T: Clone + Default + PartialEq + Send + Sync,
     C: StringCodec<T> + Default,
 {
     use_storage_with_options(
@@ -31,7 +31,7 @@ pub fn use_session_storage_with_options<T, C>(
     options: UseStorageOptions<T, C>,
 ) -> (Signal<T>, WriteSignal<T>, impl Fn() + Clone)
 where
-    T: Clone + PartialEq,
+    T: Clone + PartialEq + Send + Sync,
     C: StringCodec<T> + Default,
 {
     use_storage_with_options(StorageType::Session, key, options)

--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -283,7 +283,7 @@ where
         on_changed(mode, Rc::new(default_on_changed.clone()));
     };
 
-    create_effect({
+    Effect::new({
         let on_changed = on_changed.clone();
 
         move |_| {

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -628,7 +628,7 @@ fn read_cookies_string(
 
         let _ = ssr_cookies_header_getter;
 
-        let js_value: wasm_bindgen::JsValue = leptos::document().into();
+        let js_value: wasm_bindgen::JsValue = document().into();
         let document: web_sys::HtmlDocument = js_value.unchecked_into();
         cookies = Some(document.cookie().unwrap_or_default());
     }

--- a/src/use_cycle_list.rs
+++ b/src/use_cycle_list.rs
@@ -35,13 +35,13 @@ pub fn use_cycle_list<T, L>(
     list: L,
 ) -> UseCycleListReturn<
     T,
-    impl Fn(usize) -> T + Clone,
+    impl Fn(usize) -> T + Clone + Send + Sync,
     impl Fn() + Clone,
     impl Fn() + Clone,
     impl Fn(i64) -> T + Clone,
 >
 where
-    T: Clone + PartialEq + 'static,
+    T: Clone + PartialEq + Send + Sync + 'static,
     L: Into<MaybeSignal<Vec<T>>>,
 {
     use_cycle_list_with_options(list, UseCycleListOptions::default())
@@ -58,7 +58,7 @@ pub fn use_cycle_list_with_options<T, L>(
     impl Fn(i64) -> T + Clone,
 >
 where
-    T: Clone + PartialEq + 'static,
+    T: Clone + PartialEq + Send + Sync + 'static,
     L: Into<MaybeSignal<Vec<T>>>,
 {
     let UseCycleListOptions {

--- a/src/use_debounce_fn.rs
+++ b/src/use_debounce_fn.rs
@@ -1,8 +1,7 @@
 pub use crate::utils::DebounceOptions;
 use crate::utils::{create_filter_wrapper, create_filter_wrapper_with_arg, debounce_filter};
-use leptos::MaybeSignal;
-use std::cell::RefCell;
-use std::rc::Rc;
+use leptos::prelude::MaybeSignal;
+use std::sync::{Arc, Mutex};
 
 /// Debounce execution of a function.
 ///
@@ -77,7 +76,7 @@ use std::rc::Rc;
 pub fn use_debounce_fn<F, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
-) -> impl Fn() -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn() -> R + Clone + 'static,
     R: 'static,
@@ -90,19 +89,19 @@ pub fn use_debounce_fn_with_options<F, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
     options: DebounceOptions,
-) -> impl Fn() -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn() -> R + Clone + 'static,
     R: 'static,
 {
-    create_filter_wrapper(Rc::new(debounce_filter(ms, options)), func)
+    create_filter_wrapper(Arc::new(debounce_filter(ms, options)), func)
 }
 
 /// Version of [`use_debounce_fn`] with an argument for the debounced function. See the docs for [`use_debounce_fn`] for how to use.
 pub fn use_debounce_fn_with_arg<F, Arg, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
-) -> impl Fn(Arg) -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn(Arg) -> R + Clone + 'static,
     Arg: Clone + 'static,
@@ -116,11 +115,11 @@ pub fn use_debounce_fn_with_arg_and_options<F, Arg, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
     options: DebounceOptions,
-) -> impl Fn(Arg) -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn(Arg) -> R + Clone + 'static,
     Arg: Clone + 'static,
     R: 'static,
 {
-    create_filter_wrapper_with_arg(Rc::new(debounce_filter(ms, options)), func)
+    create_filter_wrapper_with_arg(Arc::new(debounce_filter(ms, options)), func)
 }

--- a/src/use_device_orientation.rs
+++ b/src/use_device_orientation.rs
@@ -1,6 +1,5 @@
 use cfg_if::cfg_if;
 use leptos::prelude::wrappers::read::Signal;
-use leptos::prelude::*;
 
 /// Reactive [DeviceOrientationEvent](https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent).
 /// Provide web developers with information from the physical orientation of
@@ -42,6 +41,7 @@ pub fn use_device_orientation() -> UseDeviceOrientationReturn {
         let beta = || None;
         let gamma = || None;
     } else {
+        use leptos::prelude::*;
         use crate::{use_event_listener_with_options, UseEventListenerOptions, use_supported, js};
         use leptos::ev::deviceorientation;
 
@@ -67,7 +67,7 @@ pub fn use_device_orientation() -> UseDeviceOrientationReturn {
                     .once(false),
             );
 
-            leptos::on_cleanup(cleanup);
+            on_cleanup(cleanup);
         }
     }}
 

--- a/src/use_device_pixel_ratio.rs
+++ b/src/use_device_pixel_ratio.rs
@@ -1,6 +1,5 @@
 use cfg_if::cfg_if;
 use leptos::prelude::wrappers::read::Signal;
-use leptos::prelude::*;
 
 /// Reactive [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)
 ///
@@ -31,15 +30,17 @@ use leptos::prelude::*;
 /// On the server this function returns a Signal that is always `1.0`.
 pub fn use_device_pixel_ratio() -> Signal<f64> {
     cfg_if! { if #[cfg(feature = "ssr")] {
+        use leptos::prelude::*;
         let pixel_ratio = Signal::derive(|| 1.0);
     } else {
         use crate::{use_event_listener_with_options, UseEventListenerOptions};
+        use leptos::prelude::*;
         use leptos::ev::change;
 
         let initial_pixel_ratio = window().device_pixel_ratio();
         let (pixel_ratio, set_pixel_ratio) = signal(initial_pixel_ratio);
 
-        create_effect(move |_| {
+        Effect::new(move |_| {
             let media = window().match_media(
                 &format!("(resolution: {}dppx)", pixel_ratio.get())
             ).unwrap();

--- a/src/use_display_media.rs
+++ b/src/use_display_media.rs
@@ -3,6 +3,7 @@ use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::wrappers::read::Signal;
 use leptos::prelude::*;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::{JsCast, JsValue};
 
 /// Reactive [`mediaDevices.getDisplayMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia) streaming.
@@ -55,7 +56,8 @@ pub fn use_display_media_with_options(
 
     let (enabled, set_enabled) = enabled.into_signal();
 
-    let (stream, set_stream) = signal(None::<Result<web_sys::MediaStream, JsValue>>);
+    let (stream, set_stream) =
+        signal(None::<Result<SendWrapper<web_sys::MediaStream>, SendWrapper<JsValue>>>);
 
     let _start = move || async move {
         cfg_if! { if #[cfg(not(feature = "ssr"))] {
@@ -63,7 +65,10 @@ pub fn use_display_media_with_options(
                 return;
             }
 
-            let stream = create_media(audio).await;
+            let stream = create_media(audio)
+                .await
+                .map(SendWrapper::new)
+                .map_err(SendWrapper::new);
 
             set_stream.update(|s| *s = Some(stream));
         } else {
@@ -83,7 +88,7 @@ pub fn use_display_media_with_options(
 
     let start = move || {
         cfg_if! { if #[cfg(not(feature = "ssr"))] {
-            spawn_local(async move {
+            leptos::spawn::spawn_local(async move {
                 _start().await;
                 stream.with_untracked(move |stream| {
                     if let Some(Ok(_)) = stream {
@@ -103,7 +108,7 @@ pub fn use_display_media_with_options(
         move || enabled.get(),
         move |enabled, _, _| {
             if *enabled {
-                spawn_local(async move {
+                leptos::spawn::spawn_local(async move {
                     _start().await;
                 });
             } else {
@@ -176,7 +181,7 @@ where
     /// Initially this is `None` until `start` resolved successfully.
     /// In case the stream couldn't be started, for example because the user didn't grant permission,
     /// this has the value `Some(Err(...))`.
-    pub stream: Signal<Option<Result<web_sys::MediaStream, JsValue>>>,
+    pub stream: Signal<Option<Result<SendWrapper<web_sys::MediaStream>, SendWrapper<JsValue>>>>,
 
     /// Starts the screen streaming. Triggers the ask for permission if not already granted.
     pub start: StartFn,

--- a/src/use_drop_zone.rs
+++ b/src/use_drop_zone.rs
@@ -1,7 +1,6 @@
 use crate::core::ElementMaybeSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
-use leptos::prelude::diagnostics::SpecialNonReactiveZone;
 use leptos::prelude::wrappers::read::Signal;
 use leptos::prelude::*;
 use std::fmt::{Debug, Formatter};
@@ -78,6 +77,7 @@ where
 
     #[cfg(not(feature = "ssr"))]
     {
+        use leptos::prelude::diagnostics::SpecialNonReactiveZone;
         let UseDropZoneOptions {
             on_drop,
             on_enter,

--- a/src/use_event_listener.rs
+++ b/src/use_event_listener.rs
@@ -2,7 +2,6 @@ use crate::core::ElementMaybeSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::ev::EventDescriptor;
-use leptos::prelude::diagnostics::SpecialNonReactiveZone;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use crate::{watch_with_options, WatchOptions};
@@ -120,6 +119,8 @@ where
 
     #[cfg(not(feature = "ssr"))]
     {
+        use leptos::prelude::diagnostics::SpecialNonReactiveZone;
+        use send_wrapper::SendWrapper;
         let event_name = event.name();
         let closure_js = Closure::wrap(Box::new(move |e| {
             #[cfg(debug_assertions)]
@@ -187,7 +188,8 @@ where
             cleanup_prev_element();
         };
 
-        on_cleanup(stop.clone());
+        let cleanup_stop = SendWrapper::new(stop.clone());
+        on_cleanup(move || cleanup_stop());
 
         stop
     }

--- a/src/use_infinite_scroll.rs
+++ b/src/use_infinite_scroll.rs
@@ -158,7 +158,7 @@ where
                     set_loading.set(true);
 
                     let measure = measure.clone();
-                    spawn_local(async move {
+                    leptos::spawn::spawn_local(async move {
                         #[cfg(debug_assertions)]
                         let zone = SpecialNonReactiveZone::enter();
 

--- a/src/use_intersection_observer.rs
+++ b/src/use_intersection_observer.rs
@@ -102,7 +102,7 @@ where
         let closure_js = Closure::<dyn FnMut(js_sys::Array, web_sys::IntersectionObserver)>::new(
             move |entries: js_sys::Array, observer| {
                 #[cfg(debug_assertions)]
-                let _z = SpecialNonReactiveZone::enter();
+                let _z = leptos::prelude::diagnostics::SpecialNonReactiveZone::enter();
 
                 callback(
                     entries

--- a/src/use_media_query.rs
+++ b/src/use_media_query.rs
@@ -91,7 +91,7 @@ pub fn use_media_query(query: impl Into<MaybeSignal<String>>) -> Signal<bool> {
             listener.replace(Rc::new(move |_| update()) as Rc<dyn Fn(web_sys::Event)>);
         }
 
-        create_effect(move |_| update());
+        Effect::new(move |_| update());
 
         on_cleanup(cleanup);
     }}

--- a/src/use_permission.rs
+++ b/src/use_permission.rs
@@ -46,12 +46,12 @@ pub fn use_permission(permission_name: &str) -> Signal<PermissionState> {
             }
         };
 
-        spawn_local({
+        leptos::spawn::spawn_local({
             let permission_name = permission_name.to_owned();
 
             async move {
                 if let Ok(status) = query_permission(permission_name).await {
-                    let _ = use_event_listener(status.clone(), ev::change, {
+                    let _ = use_event_listener(status.clone(), leptos::ev::change, {
                         let on_change = on_change.clone();
                         move |_| on_change()
                     });

--- a/src/use_preferred_dark.rs
+++ b/src/use_preferred_dark.rs
@@ -1,5 +1,4 @@
 use crate::use_media_query;
-use leptos::prelude::wrappers::read::Signal;
 use leptos::prelude::*;
 
 /// Reactive [dark theme preference](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).

--- a/src/use_raf_fn.rs
+++ b/src/use_raf_fn.rs
@@ -138,7 +138,8 @@ pub fn use_raf_fn_with_options(
         resume();
     }
 
-    on_cleanup(pause.clone());
+    let pause_cleanup = send_wrapper::SendWrapper::new(pause.clone());
+    on_cleanup(move || pause_cleanup());
 
     Pausable {
         resume,

--- a/src/use_scroll.rs
+++ b/src/use_scroll.rs
@@ -11,6 +11,7 @@ use crate::use_event_listener::use_event_listener_with_options;
 use crate::{
     use_debounce_fn_with_arg, use_throttle_fn_with_arg_and_options, ThrottleOptions,
 };
+use leptos::ev;
 use leptos::ev::scrollend;
 use wasm_bindgen::JsCast;
 
@@ -202,13 +203,13 @@ where
 
     let (is_scrolling, set_is_scrolling) = signal(false);
 
-    let arrived_state = create_rw_signal(Directions {
+    let arrived_state = RwSignal::new(Directions {
         left: true,
         right: false,
         top: true,
         bottom: false,
     });
-    let directions = create_rw_signal(Directions {
+    let directions = RwSignal::new(Directions {
         left: false,
         right: false,
         top: false,

--- a/src/use_supported.rs
+++ b/src/use_supported.rs
@@ -1,4 +1,3 @@
-use leptos::prelude::wrappers::read::Signal;
 use leptos::prelude::*;
 
 /// SSR compatibe `is_supported`

--- a/src/use_throttle_fn.rs
+++ b/src/use_throttle_fn.rs
@@ -1,7 +1,6 @@
 use crate::utils::{create_filter_wrapper, create_filter_wrapper_with_arg, throttle_filter};
-use leptos::MaybeSignal;
-use std::cell::RefCell;
-use std::rc::Rc;
+use leptos::prelude::MaybeSignal;
+use std::sync::{Arc, Mutex};
 
 pub use crate::utils::ThrottleOptions;
 
@@ -73,7 +72,7 @@ pub use crate::utils::ThrottleOptions;
 pub fn use_throttle_fn<F, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
-) -> impl Fn() -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn() -> R + Clone + 'static,
     R: 'static,
@@ -86,19 +85,19 @@ pub fn use_throttle_fn_with_options<F, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
     options: ThrottleOptions,
-) -> impl Fn() -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn() -> R + Clone + 'static,
     R: 'static,
 {
-    create_filter_wrapper(Rc::new(throttle_filter(ms, options)), func)
+    create_filter_wrapper(Arc::new(throttle_filter(ms, options)), func)
 }
 
 /// Version of [`use_throttle_fn`] with an argument for the throttled function. See the docs for [`use_throttle_fn`] for how to use.
 pub fn use_throttle_fn_with_arg<F, Arg, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
-) -> impl Fn(Arg) -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn(Arg) -> R + Clone + 'static,
     Arg: Clone + 'static,
@@ -112,11 +111,11 @@ pub fn use_throttle_fn_with_arg_and_options<F, Arg, R>(
     func: F,
     ms: impl Into<MaybeSignal<f64>> + 'static,
     options: ThrottleOptions,
-) -> impl Fn(Arg) -> Rc<RefCell<Option<R>>> + Clone
+) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn(Arg) -> R + Clone + 'static,
     Arg: Clone + 'static,
     R: 'static,
 {
-    create_filter_wrapper_with_arg(Rc::new(throttle_filter(ms, options)), func)
+    create_filter_wrapper_with_arg(Arc::new(throttle_filter(ms, options)), func)
 }

--- a/src/use_web_notification.rs
+++ b/src/use_web_notification.rs
@@ -1,9 +1,8 @@
 use crate::{use_supported, use_window};
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
-use leptos::prelude::diagnostics::SpecialNonReactiveZone;
-use leptos::prelude::wrappers::read::Signal;
-use leptos::prelude::*;
+use leptos::prelude::{wrappers::read::Signal, *};
+use send_wrapper::SendWrapper;
 use std::rc::Rc;
 
 /// Reactive [Notification API](https://developer.mozilla.org/en-US/docs/Web/API/Notification).
@@ -53,7 +52,7 @@ pub fn use_web_notification_with_options(
 ) -> UseWebNotificationReturn<impl Fn(ShowOptions) + Clone, impl Fn() + Clone> {
     let is_supported = use_supported(browser_supports_notifications);
 
-    let (notification, set_notification) = signal(None::<web_sys::Notification>);
+    let (notification, set_notification) = signal(None::<SendWrapper<web_sys::Notification>>);
 
     let (permission, set_permission) = signal(NotificationPermission::default());
 
@@ -65,6 +64,7 @@ pub fn use_web_notification_with_options(
         let show = move |_: ShowOptions| ();
         let close = move || ();
     } else {
+        use leptos::{spawn::spawn_local, prelude::diagnostics::SpecialNonReactiveZone};
         use crate::use_event_listener;
         use leptos::ev::visibilitychange;
         use wasm_bindgen::closure::Closure;
@@ -462,7 +462,7 @@ where
     CloseFn: Fn() + Clone,
 {
     pub is_supported: Signal<bool>,
-    pub notification: Signal<Option<web_sys::Notification>>,
+    pub notification: Signal<Option<SendWrapper<web_sys::Notification>>>,
     pub show: ShowFn,
     pub close: CloseFn,
     pub permission: Signal<NotificationPermission>,

--- a/src/watch_with_options.rs
+++ b/src/watch_with_options.rs
@@ -1,7 +1,7 @@
 use crate::filter_builder_methods;
 use crate::utils::{create_filter_wrapper, DebounceOptions, FilterOptions, ThrottleOptions};
 use default_struct_builder::DefaultBuilder;
-use leptos::prelude::*;
+use leptos::prelude::{diagnostics::SpecialNonReactiveZone, *};
 use std::cell::RefCell;
 use std::rc::Rc;
 


### PR DESCRIPTION
This PR makes progress towards updating `leptos-use` for Leptos 0.7 (now on `0.7.0-alpha`).

Given the extensive nature of these changes, this PR may be impractical from a review standpoint. However, it may at least be useful as a point of reference for what needs to be done.

There are four main blockers at the moment:
1. It appears [queue_microtasks](https://docs.rs/leptos/latest/leptos/fn.queue_microtask.html) is not yet implemented in 0.7
2. `watch` is not yet implemented in 0.7 [as noted here on Discord](https://discord.com/channels/1031524867910148188/1234308989970550834/1263091619339436065).
3. There is no equivalent to [leptos::ev::Custom](https://docs.rs/leptos/latest/leptos/ev/struct.Custom.html). This may simply be an oversight, as it appears to be very simple.
4. The `HtmlElement` struct has gotten [much more complicated](https://docs.rs/leptos/0.7.0-alpha/leptos/html/struct.HtmlElement.html) and I'm not sure what the best approach is for managing `ElementMaybeSignal`-related code.

With all this in mind, it seems like the most helpful way forward would be implementing the missing items in 1-3, and that might be pretty easy!

In any case, I hope this helps!