### PR TITLE
Fix `web_sys_unstable_apis` not passed to rustdoc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
-[unstable]
+[build]
 rustflags = ["--cfg=web_sys_unstable_apis"]
 rustdocflags = ["--cfg=web_sys_unstable_apis"]

--- a/src/use_clipboard.rs
+++ b/src/use_clipboard.rs
@@ -11,7 +11,7 @@ use leptos::*;
 /// Without user permission, reading or altering the clipboard contents is not permitted.
 ///
 /// > This function requires `--cfg=web_sys_unstable_apis` to be activated as
-/// [described in the wasm-bindgen guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html).
+/// > [described in the wasm-bindgen guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html).
 ///
 /// ## Demo
 ///
@@ -89,7 +89,7 @@ pub fn use_clipboard_with_options(
     };
 
     if is_supported.get() && read {
-        let _ = use_event_listener(window(), copy, update_text.clone());
+        let _ = use_event_listener(window(), copy, update_text);
         let _ = use_event_listener(window(), cut, update_text);
     }
 


### PR DESCRIPTION
Resolves #105. See https://github.com/rust-lang/cargo/issues/9138#issuecomment-774074873