### PR TITLE
Rework of `UseMouseCoordType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed 🗑
+
+- Removed `UseMouseEventExtractorDefault`
+
 ## [0.11.4] - 2024-08-12
 
 ### New Features 🚀

--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -58,8 +58,8 @@ where
         .map(|l| l.as_ref().clone())
         .collect::<Vec<_>>();
 
-    const EMPTY_ERR_MSG: &'static str = "Empty supported list. You have to provide at least one locale in the `supported` parameter";
-    assert!(supported.len() > 0, "{}", EMPTY_ERR_MSG);
+    const EMPTY_ERR_MSG: &str = "Empty supported list. You have to provide at least one locale in the `supported` parameter";
+    assert!(!supported.is_empty(), "{}", EMPTY_ERR_MSG);
 
     Signal::derive(move || {
         let supported = supported.clone();

--- a/src/use_mouse.rs
+++ b/src/use_mouse.rs
@@ -273,9 +273,7 @@ impl<E: UseMouseEventExtractor + Clone> UseMouseEventExtractor for UseMouseCoord
             UseMouseCoordType::Page => (event.page_x() as f64, event.page_y() as f64),
             UseMouseCoordType::Client => (event.client_x() as f64, event.client_y() as f64),
             UseMouseCoordType::Screen => (event.screen_x() as f64, event.client_y() as f64),
-            UseMouseCoordType::Movement => {
-                (event.movement_x() as f64, event.movement_y() as f64)
-            }
+            UseMouseCoordType::Movement => (event.movement_x() as f64, event.movement_y() as f64),
             UseMouseCoordType::Custom(ref extractor) => extractor.extract_mouse_coords(event),
         }
     }

--- a/src/use_mouse.rs
+++ b/src/use_mouse.rs
@@ -109,10 +109,11 @@ where
         move |event: web_sys::MouseEvent| {
             let result = coord_type.extract_mouse_coords(&event);
 
-            let (x, y) = result;
-            set_x.set(x);
-            set_y.set(y);
-            set_source_type.set(UseMouseSourceType::Mouse);
+            if let Some((x, y)) = result {
+                set_x.set(x);
+                set_y.set(y);
+                set_source_type.set(UseMouseSourceType::Mouse);
+            }
         }
     };
 
@@ -137,10 +138,11 @@ where
                         .expect("Just checked that there's at least on touch"),
                 );
 
-                let (x, y) = result;
-                set_x.set(x);
-                set_y.set(y);
-                set_source_type.set(UseMouseSourceType::Touch);
+                if let Some((x, y)) = result {
+                    set_x.set(x);
+                    set_y.set(y);
+                    set_source_type.set(UseMouseSourceType::Touch);
+                }
             }
         }
     };
@@ -244,7 +246,7 @@ impl Default for UseMouseOptions<UseWindow, web_sys::Window, Infallible> {
 
 /// Defines how to get the coordinates from the event.
 #[derive(Clone)]
-pub enum UseMouseCoordType<E> {
+pub enum UseMouseCoordType<E: UseMouseEventExtractor + Clone> {
     Page,
     Client,
     Screen,
@@ -279,7 +281,9 @@ impl<E: UseMouseEventExtractor + Clone> UseMouseEventExtractor for UseMouseCoord
             UseMouseCoordType::Client => (event.client_x() as f64, event.client_y() as f64),
             UseMouseCoordType::Screen => (event.screen_x() as f64, event.client_y() as f64),
             UseMouseCoordType::Movement => (event.movement_x() as f64, event.movement_y() as f64),
-            UseMouseCoordType::Custom(ref extractor) => return extractor.extract_mouse_coords(event),
+            UseMouseCoordType::Custom(ref extractor) => {
+                return extractor.extract_mouse_coords(event)
+            }
         })
     }
 
@@ -289,7 +293,9 @@ impl<E: UseMouseEventExtractor + Clone> UseMouseEventExtractor for UseMouseCoord
             UseMouseCoordType::Client => (touch.client_x() as f64, touch.client_y() as f64),
             UseMouseCoordType::Screen => (touch.screen_x() as f64, touch.client_y() as f64),
             UseMouseCoordType::Movement => return None,
-            UseMouseCoordType::Custom(ref extractor) => return extractor.extract_touch_coords(touch),
+            UseMouseCoordType::Custom(ref extractor) => {
+                return extractor.extract_touch_coords(touch)
+            }
         })
     }
 }

--- a/src/use_mouse.rs
+++ b/src/use_mouse.rs
@@ -276,27 +276,25 @@ pub trait UseMouseEventExtractor {
 
 impl<E: UseMouseEventExtractor + Clone> UseMouseEventExtractor for UseMouseCoordType<E> {
     fn extract_mouse_coords(&self, event: &web_sys::MouseEvent) -> Option<(f64, f64)> {
-        Some(match self {
-            UseMouseCoordType::Page => (event.page_x() as f64, event.page_y() as f64),
-            UseMouseCoordType::Client => (event.client_x() as f64, event.client_y() as f64),
-            UseMouseCoordType::Screen => (event.screen_x() as f64, event.client_y() as f64),
-            UseMouseCoordType::Movement => (event.movement_x() as f64, event.movement_y() as f64),
-            UseMouseCoordType::Custom(ref extractor) => {
-                return extractor.extract_mouse_coords(event)
+        match self {
+            UseMouseCoordType::Page => Some((event.page_x() as f64, event.page_y() as f64)),
+            UseMouseCoordType::Client => Some((event.client_x() as f64, event.client_y() as f64)),
+            UseMouseCoordType::Screen => Some((event.screen_x() as f64, event.client_y() as f64)),
+            UseMouseCoordType::Movement => {
+                Some((event.movement_x() as f64, event.movement_y() as f64))
             }
-        })
+            UseMouseCoordType::Custom(ref extractor) => extractor.extract_mouse_coords(event),
+        }
     }
 
     fn extract_touch_coords(&self, touch: &web_sys::Touch) -> Option<(f64, f64)> {
-        Some(match self {
-            UseMouseCoordType::Page => (touch.page_x() as f64, touch.page_y() as f64),
-            UseMouseCoordType::Client => (touch.client_x() as f64, touch.client_y() as f64),
-            UseMouseCoordType::Screen => (touch.screen_x() as f64, touch.client_y() as f64),
-            UseMouseCoordType::Movement => return None,
-            UseMouseCoordType::Custom(ref extractor) => {
-                return extractor.extract_touch_coords(touch)
-            }
-        })
+        match self {
+            UseMouseCoordType::Page => Some((touch.page_x() as f64, touch.page_y() as f64)),
+            UseMouseCoordType::Client => Some((touch.client_x() as f64, touch.client_y() as f64)),
+            UseMouseCoordType::Screen => Some((touch.screen_x() as f64, touch.client_y() as f64)),
+            UseMouseCoordType::Movement => None,
+            UseMouseCoordType::Custom(ref extractor) => extractor.extract_touch_coords(touch),
+        }
     }
 }
 

--- a/src/use_mouse.rs
+++ b/src/use_mouse.rs
@@ -109,11 +109,10 @@ where
         move |event: web_sys::MouseEvent| {
             let result = coord_type.extract_mouse_coords(&event);
 
-            if let (x, y) = result {
-                set_x.set(x);
-                set_y.set(y);
-                set_source_type.set(UseMouseSourceType::Mouse);
-            }
+            let (x, y) = result;
+            set_x.set(x);
+            set_y.set(y);
+            set_source_type.set(UseMouseSourceType::Mouse);
         }
     };
 
@@ -138,11 +137,10 @@ where
                         .expect("Just checked that there's at least on touch"),
                 );
 
-                if let (x, y) = result {
-                    set_x.set(x);
-                    set_y.set(y);
-                    set_source_type.set(UseMouseSourceType::Touch);
-                }
+                let (x, y) = result;
+                set_x.set(x);
+                set_y.set(y);
+                set_source_type.set(UseMouseSourceType::Touch);
             }
         }
     };
@@ -234,7 +232,7 @@ where
 impl Default for UseMouseOptions<UseWindow, web_sys::Window, Infallible> {
     fn default() -> Self {
         Self {
-            coord_type: UseMouseCoordType::<Infallible>::default(),
+            coord_type: UseMouseCoordType::default(),
             target: use_window(),
             touch: true,
             reset_on_touch_ends: false,
@@ -254,7 +252,7 @@ pub enum UseMouseCoordType<E> {
     Custom(E),
 }
 
-impl<E> Default for UseMouseCoordType<E> {
+impl Default for UseMouseCoordType<Infallible> {
     fn default() -> Self {
         Self::Page
     }

--- a/src/use_mouse_in_element.rs
+++ b/src/use_mouse_in_element.rs
@@ -1,11 +1,12 @@
 use crate::core::{ElementMaybeSignal, Position};
 use crate::{
     use_mouse_with_options, use_window, UseMouseCoordType, UseMouseEventExtractor,
-    UseMouseEventExtractorDefault, UseMouseOptions, UseMouseReturn, UseMouseSourceType, UseWindow,
+    UseMouseOptions, UseMouseReturn, UseMouseSourceType, UseWindow,
 };
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::*;
+use std::convert::Infallible;
 use std::marker::PhantomData;
 
 /// Reactive mouse position related to an element.
@@ -196,11 +197,11 @@ where
 }
 
 impl Default
-    for UseMouseInElementOptions<UseWindow, web_sys::Window, UseMouseEventExtractorDefault>
+    for UseMouseInElementOptions<UseWindow, web_sys::Window, Infallible>
 {
     fn default() -> Self {
         Self {
-            coord_type: UseMouseCoordType::<UseMouseEventExtractorDefault>::default(),
+            coord_type: UseMouseCoordType::<Infallible>::default(),
             target: use_window(),
             touch: true,
             reset_on_touch_ends: false,

--- a/src/use_mouse_in_element.rs
+++ b/src/use_mouse_in_element.rs
@@ -199,7 +199,7 @@ where
 impl Default for UseMouseInElementOptions<UseWindow, web_sys::Window, Infallible> {
     fn default() -> Self {
         Self {
-            coord_type: UseMouseCoordType::<Infallible>::default(),
+            coord_type: UseMouseCoordType::default(),
             target: use_window(),
             touch: true,
             reset_on_touch_ends: false,

--- a/src/use_mouse_in_element.rs
+++ b/src/use_mouse_in_element.rs
@@ -1,7 +1,7 @@
 use crate::core::{ElementMaybeSignal, Position};
 use crate::{
-    use_mouse_with_options, use_window, UseMouseCoordType, UseMouseEventExtractor,
-    UseMouseOptions, UseMouseReturn, UseMouseSourceType, UseWindow,
+    use_mouse_with_options, use_window, UseMouseCoordType, UseMouseEventExtractor, UseMouseOptions,
+    UseMouseReturn, UseMouseSourceType, UseWindow,
 };
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
@@ -196,9 +196,7 @@ where
     _marker: PhantomData<T>,
 }
 
-impl Default
-    for UseMouseInElementOptions<UseWindow, web_sys::Window, Infallible>
-{
+impl Default for UseMouseInElementOptions<UseWindow, web_sys::Window, Infallible> {
     fn default() -> Self {
         Self {
             coord_type: UseMouseCoordType::<Infallible>::default(),


### PR DESCRIPTION
I was unhappy with how `UseMouseCoordType` and `UseMouseEventExtractor` were setup, and especially I did not like the "useless" existence of `UseMouseEventExtractorDefault`.

This makes the following changes:
1. `UseMouseEventExtractorDefault` is removed.
2. `UseMouseCoordType<E>` now has a `Default` implementation for the type `UseMouseCoordType<Infallible>`.