### PR TITLE
fixed an error for a match on a non exhaustive enum

### DIFF
--- a/src/use_web_notification.rs
+++ b/src/use_web_notification.rs
@@ -481,7 +481,7 @@ impl From<web_sys::NotificationPermission> for NotificationPermission {
             web_sys::NotificationPermission::Default => Self::Default,
             web_sys::NotificationPermission::Granted => Self::Granted,
             web_sys::NotificationPermission::Denied => Self::Denied,
-            web_sys::NotificationPermission::__Nonexhaustive => Self::Default,
+            _ => Self::Default,
         }
     }
 }


### PR DESCRIPTION
Prior to `wasm-bindgen v0.2.93`, `#[wasm_bindgen]` on an enum made it "non-exhaustive" by adding a `__Nonexhaustive` variant, with the new release of `v0.2.93` it does'nt introduce that variant anymore and just use `#[non_exhaustive]`. This PR solves this issue, for both prior versions and incoming version of `wasm-bindgen`.

I did a quick search and this is the only instance of the use of this "fake" variant in the codebase.