### PR TITLE
Allow for lazy protocols with use_websocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,7 @@ use_web_notification = [
     "web-sys/NotificationDirection",
     "web-sys/VisibilityState"
 ]
-use_websocket = ["dep:codee"]
+use_websocket = ["dep:web-sys", "dep:codee"]
 use_window = ["use_document", "dep:web-sys", "web-sys/Navigator", "web-sys/MediaQueryList"]
 use_window_focus = ["use_event_listener"]
 use_window_scroll = ["use_event_listener", "use_window"]

--- a/src/use_websocket.rs
+++ b/src/use_websocket.rs
@@ -652,6 +652,11 @@ where
     /// Defaults to `true`.
     immediate: bool,
     /// Sub protocols. See [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#protocols).
+    ///
+    /// Can be set as a signal to support protocols only available after the initial render.
+    ///
+    /// Note that protocols are only updated on the next websocket open() call, not whenever the signal is updated.
+    /// Therefore "lazy" protocols should use the `immediate(false)` option and manually call `open()`.
     #[builder(into)]
     protocols: MaybeSignal<Option<Vec<String>>>,
 }

--- a/src/use_websocket.rs
+++ b/src/use_websocket.rs
@@ -344,17 +344,19 @@ where
                 }
 
                 let web_socket = {
-                    protocols.as_ref().map_or_else(
-                        || WebSocket::new(&url).unwrap_throw(),
-                        |protocols| {
-                            let array = protocols
-                                .iter()
-                                .map(|p| JsValue::from(p.clone()))
-                                .collect::<Array>();
-                            WebSocket::new_with_str_sequence(&url, &JsValue::from(&array))
-                                .unwrap_throw()
-                        },
-                    )
+                    protocols.with_untracked(|protocols| {
+                        protocols.as_ref().map_or_else(
+                            || WebSocket::new(&url).unwrap_throw(),
+                            |protocols| {
+                                let array = protocols
+                                    .iter()
+                                    .map(|p| JsValue::from(p.clone()))
+                                    .collect::<Array>();
+                                WebSocket::new_with_str_sequence(&url, &JsValue::from(&array))
+                                    .unwrap_throw()
+                            },
+                        )
+                    })
                 };
                 web_socket.set_binary_type(BinaryType::Arraybuffer);
                 set_ready_state.set(ConnectionReadyState::Connecting);
@@ -650,7 +652,8 @@ where
     /// Defaults to `true`.
     immediate: bool,
     /// Sub protocols. See [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#protocols).
-    protocols: Option<Vec<String>>,
+    #[builder(into)]
+    protocols: MaybeSignal<Option<Vec<String>>>,
 }
 
 impl<Rx: ?Sized, E, D> UseWebSocketOptions<Rx, E, D> {


### PR DESCRIPTION
I have a need to use the `protocols` option of websockets, but I can only get them asyncronously. This PR provides a way to have "async" protocols by wrapping `Option<Vec<String>>` in `MaybeSignal`. Combining e.g. an async resource as the protocol signal with `opts.immediate(false)` and manually calling `ws.open()` once the resource has loaded solves the issue.

This is definitely a weird implementation though, if you have a better way to do it I can update the PR?

This shouldn't be a breaking change, all previous config of the protocol option should be unaffected, due to the `impl Into<MaybeSignal<...>>`