### PR TITLE
Fix import issues with leptos version 0.7.0-gamma2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-use"
-version = "0.14.0-beta4"
+version = "0.14.0-beta5"
 edition = "2021"
 authors = ["Marc-Stefan Cassola"]
 categories = ["gui", "web-programming", "wasm"]
@@ -26,9 +26,9 @@ http1 = { version = "1", optional = true, package = "http" }
 http0_2 = { version = "0.2", optional = true, package = "http" }
 js-sys = "0.3"
 lazy_static = "1"
-leptos = "0.7.0-beta5"
-leptos_axum = { version = "0.7.0-beta5", optional = true }
-leptos_actix = { version = "0.7.0-beta5", optional = true }
+leptos = "0.7.0-gamma2"
+leptos_axum = { version = "0.7.0-gamma2", optional = true }
+leptos_actix = { version = "0.7.0-gamma2", optional = true }
 leptos-spin = { version = "0.2", optional = true }
 num = { version = "0.4", optional = true }
 paste = "1"
@@ -47,7 +47,7 @@ codee = { version = "0.2", features = [
     "prost",
 ] }
 getrandom = { version = "0.2", features = ["js"] }
-leptos_meta = { version = "0.7.0-beta5" }
+leptos_meta = { version = "0.7.0-gamma2" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 unic-langid = { version = "0.9", features = ["macros"] }

--- a/examples/use_webtransport/src/main.rs
+++ b/examples/use_webtransport/src/main.rs
@@ -64,7 +64,7 @@ fn Demo() -> impl IntoView {
         move |_| {
             let transport = transport.clone();
 
-            leptos::spawn::spawn_local(async move {
+            leptos::task::spawn_local(async move {
                 match transport.open_bidir_stream().await {
                     Ok(bidir_stream) => {
                         let i = id.get_value();

--- a/src/core/element_maybe_signal.rs
+++ b/src/core/element_maybe_signal.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::ops::Deref;
 
 /// Used as an argument type to make it easily possible to pass either

--- a/src/core/elements_maybe_signal.rs
+++ b/src/core/elements_maybe_signal.rs
@@ -1,6 +1,6 @@
 use crate::core::{SignalMarker, SignalStrMarker};
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::ops::Deref;
 
 /// Used as an argument type to make it easily possible to pass either

--- a/src/math/use_abs.rs
+++ b/src/math/use_abs.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_simple_math;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use num::Float;
 use paste::paste;
 

--- a/src/math/use_and.rs
+++ b/src/math/use_and.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_binary_logic;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use paste::paste;
 
 use_binary_logic!(

--- a/src/math/use_ceil.rs
+++ b/src/math/use_ceil.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_simple_math;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use num::Float;
 use paste::paste;
 

--- a/src/math/use_floor.rs
+++ b/src/math/use_floor.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_simple_math;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use num::Float;
 use paste::paste;
 

--- a/src/math/use_max.rs
+++ b/src/math/use_max.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_partial_cmp;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::cmp::Ordering;
 
 use_partial_cmp!(

--- a/src/math/use_min.rs
+++ b/src/math/use_min.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_partial_cmp;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::cmp::Ordering;
 
 use_partial_cmp!(

--- a/src/math/use_not.rs
+++ b/src/math/use_not.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Reactive `NOT` condition.
 ///

--- a/src/math/use_or.rs
+++ b/src/math/use_or.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_binary_logic;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use paste::paste;
 
 use_binary_logic!(

--- a/src/math/use_round.rs
+++ b/src/math/use_round.rs
@@ -1,6 +1,6 @@
 use crate::math::shared::use_simple_math;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use num::Float;
 use paste::paste;
 

--- a/src/on_click_outside.rs
+++ b/src/on_click_outside.rs
@@ -169,7 +169,7 @@ where
                     }
 
                     #[cfg(debug_assertions)]
-                    let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                    let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                     handler(event.into());
                 }

--- a/src/signal_debounced.rs
+++ b/src/signal_debounced.rs
@@ -1,7 +1,7 @@
 use crate::utils::signal_filtered;
 use crate::{use_debounce_fn_with_options, DebounceOptions};
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use paste::paste;
 
 signal_filtered!(

--- a/src/signal_throttled.rs
+++ b/src/signal_throttled.rs
@@ -1,7 +1,7 @@
 use crate::utils::signal_filtered;
 use crate::{use_throttle_fn_with_options, ThrottleOptions};
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use paste::paste;
 
 signal_filtered!(

--- a/src/storage/use_local_storage.rs
+++ b/src/storage/use_local_storage.rs
@@ -1,7 +1,7 @@
 use super::{use_storage_with_options, StorageType, UseStorageOptions};
 use codee::{Decoder, Encoder};
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 #[allow(rustdoc::bare_urls)]
 /// Reactive [LocalStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).

--- a/src/storage/use_storage.rs
+++ b/src/storage/use_storage.rs
@@ -2,7 +2,7 @@ use crate::{core::MaybeRwSignal, storage::StorageType, utils::FilterOptions};
 use codee::{CodecError, Decoder, Encoder};
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::sync::Arc;
 use thiserror::Error;
 use wasm_bindgen::JsValue;

--- a/src/use_active_element.rs
+++ b/src/use_active_element.rs
@@ -3,7 +3,7 @@
 use crate::{use_document, use_event_listener_with_options, use_window, UseEventListenerOptions};
 use leptos::ev::{blur, focus};
 use leptos::html::{AnyElement, ToHtmlElement};
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use leptos::prelude::*;
 
 /// Reactive `document.activeElement`

--- a/src/use_breakpoints.rs
+++ b/src/use_breakpoints.rs
@@ -1,7 +1,7 @@
 use crate::{use_media_query, use_window};
 use leptos::logging::error;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use paste::paste;
 use std::collections::HashMap;
 use std::fmt::Debug;

--- a/src/use_clipboard.rs
+++ b/src/use_clipboard.rs
@@ -2,7 +2,7 @@ use crate::{js, js_fut, use_event_listener, use_supported, UseTimeoutFnReturn};
 use default_struct_builder::DefaultBuilder;
 use leptos::ev::{copy, cut};
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Reactive [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API).
 ///
@@ -77,7 +77,7 @@ pub fn use_clipboard_with_options(
 
     let update_text = move |_| {
         if is_supported.get() {
-            leptos::spawn::spawn_local(async move {
+            leptos::task::spawn_local(async move {
                 let clipboard = window().navigator().clipboard();
                 if let Ok(text) = js_fut!(clipboard.read_text()).await {
                     set_text.set(text.as_string());
@@ -99,7 +99,7 @@ pub fn use_clipboard_with_options(
                 let start = start.clone();
                 let value = value.to_owned();
 
-                leptos::spawn::spawn_local(async move {
+                leptos::task::spawn_local(async move {
                     let clipboard = window().navigator().clipboard();
                     if js_fut!(clipboard.write_text(&value)).await.is_ok() {
                         set_text.set(Some(value));

--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -9,7 +9,7 @@ use crate::{
 use codee::string::FromToStringCodec;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
 use std::str::FromStr;

--- a/src/use_device_orientation.rs
+++ b/src/use_device_orientation.rs
@@ -1,5 +1,5 @@
 use cfg_if::cfg_if;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Reactive [DeviceOrientationEvent](https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent).
 ///

--- a/src/use_display_media.rs
+++ b/src/use_display_media.rs
@@ -2,7 +2,7 @@ use crate::core::MaybeRwSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use wasm_bindgen::{JsCast, JsValue};
 
 /// Reactive [`mediaDevices.getDisplayMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia) streaming.
@@ -83,7 +83,7 @@ pub fn use_display_media_with_options(
 
     let start = move || {
         cfg_if! { if #[cfg(not(feature = "ssr"))] {
-            leptos::spawn::spawn_local(async move {
+            leptos::task::spawn_local(async move {
                 _start().await;
                 stream.with_untracked(move |stream| {
                     if let Some(Ok(_)) = stream {
@@ -103,7 +103,7 @@ pub fn use_display_media_with_options(
         move || enabled.get(),
         move |enabled, _, _| {
             if *enabled {
-                leptos::spawn::spawn_local(async move {
+                leptos::task::spawn_local(async move {
                     _start().await;
                 });
             } else {

--- a/src/use_document_visibility.rs
+++ b/src/use_document_visibility.rs
@@ -4,7 +4,7 @@ use crate::use_event_listener;
 use cfg_if::cfg_if;
 use leptos::ev::visibilitychange;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Reactively track `document.visibilityState`
 ///

--- a/src/use_draggable.rs
+++ b/src/use_draggable.rs
@@ -3,7 +3,7 @@ use crate::{use_event_listener_with_options, use_window, UseEventListenerOptions
 use default_struct_builder::DefaultBuilder;
 use leptos::ev::{pointerdown, pointermove, pointerup};
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use wasm_bindgen::JsCast;
@@ -123,7 +123,7 @@ where
                 };
 
                 #[cfg(debug_assertions)]
-                let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 if !on_start(UseDraggableCallbackArgs {
                     position,
@@ -158,7 +158,7 @@ where
                 set_position.set(position);
 
                 #[cfg(debug_assertions)]
-                let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 on_move(UseDraggableCallbackArgs {
                     position,
@@ -183,7 +183,7 @@ where
         set_start_position.set(None);
 
         #[cfg(debug_assertions)]
-        let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+        let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
         on_end(UseDraggableCallbackArgs {
             position: position.get_untracked(),

--- a/src/use_drop_zone.rs
+++ b/src/use_drop_zone.rs
@@ -2,7 +2,7 @@ use crate::core::IntoElementMaybeSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -106,7 +106,7 @@ where
             update_files(&event);
 
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             on_enter(UseDropZoneEvent {
                 files: files.get_untracked().into_iter().collect(),
@@ -119,7 +119,7 @@ where
             update_files(&event);
 
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             on_over(UseDropZoneEvent {
                 files: files.get_untracked().into_iter().collect(),
@@ -137,7 +137,7 @@ where
             update_files(&event);
 
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             on_leave(UseDropZoneEvent {
                 files: files.get_untracked().into_iter().collect(),
@@ -153,7 +153,7 @@ where
             update_files(&event);
 
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             on_drop(UseDropZoneEvent {
                 files: files.get_untracked().into_iter().collect(),

--- a/src/use_element_bounding.rs
+++ b/src/use_element_bounding.rs
@@ -1,7 +1,7 @@
 use crate::core::IntoElementMaybeSignal;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Reactive [bounding box](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) of an HTML element
 ///

--- a/src/use_element_hover.rs
+++ b/src/use_element_hover.rs
@@ -5,7 +5,7 @@ use default_struct_builder::DefaultBuilder;
 use leptos::ev::{mouseenter, mouseleave};
 use leptos::leptos_dom::helpers::TimeoutHandle;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use std::time::Duration;

--- a/src/use_element_size.rs
+++ b/src/use_element_size.rs
@@ -3,7 +3,7 @@ use crate::core::Size;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use crate::{use_resize_observer_with_options, UseResizeObserverOptions};

--- a/src/use_element_visibility.rs
+++ b/src/use_element_visibility.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 
 #[cfg(not(feature = "ssr"))]
 use crate::{use_intersection_observer_with_options, UseIntersectionObserverOptions};
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Tracks the visibility of an element within the viewport.
 ///

--- a/src/use_event_listener.rs
+++ b/src/use_event_listener.rs
@@ -122,7 +122,7 @@ where
         let event_name = event.name();
         let closure_js = Closure::wrap(Box::new(move |e| {
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             handler(e);
         }) as Box<dyn FnMut(_)>)

--- a/src/use_event_source.rs
+++ b/src/use_event_source.rs
@@ -235,7 +235,7 @@ where
                         } else {
                             #[cfg(debug_assertions)]
                             let _z =
-                                leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter(
+                                leptos::reactive::diagnostics::SpecialNonReactiveZone::enter(
                                 );
 
                             on_failed();

--- a/src/use_favicon.rs
+++ b/src/use_favicon.rs
@@ -4,7 +4,7 @@ use crate::core::MaybeRwSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use wasm_bindgen::JsCast;
 
 /// Reactive favicon.

--- a/src/use_geolocation.rs
+++ b/src/use_geolocation.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Reactive [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API).
 ///

--- a/src/use_idle.rs
+++ b/src/use_idle.rs
@@ -4,7 +4,7 @@ use crate::utils::{DebounceOptions, FilterOptions, ThrottleOptions};
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 ///
 ///

--- a/src/use_infinite_scroll.rs
+++ b/src/use_infinite_scroll.rs
@@ -7,7 +7,7 @@ use default_struct_builder::DefaultBuilder;
 use futures_util::join;
 use gloo_timers::future::sleep;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -154,10 +154,10 @@ where
                     set_loading.set(true);
 
                     let measure = measure.clone();
-                    leptos::spawn::spawn_local(async move {
+                    leptos::task::spawn_local(async move {
                         #[cfg(debug_assertions)]
                         let zone =
-                            leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                            leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                         join!(
                             on_load_more.with_value(|f| f(state)),

--- a/src/use_intersection_observer.rs
+++ b/src/use_intersection_observer.rs
@@ -2,7 +2,7 @@ use crate::core::{IntoElementMaybeSignal, IntoElementsMaybeSignal};
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::marker::PhantomData;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
@@ -103,7 +103,7 @@ where
         let closure_js = Closure::<dyn FnMut(js_sys::Array, web_sys::IntersectionObserver)>::new(
             move |entries: js_sys::Array, observer| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 callback(
                     entries

--- a/src/use_interval.rs
+++ b/src/use_interval.rs
@@ -2,7 +2,7 @@ use crate::utils::Pausable;
 use crate::{use_interval_fn_with_options, UseIntervalFnOptions};
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::rc::Rc;
 
 /// Reactive counter increases on every interval.

--- a/src/use_interval_fn.rs
+++ b/src/use_interval_fn.rs
@@ -104,7 +104,7 @@ where
 
                 move || {
                     #[cfg(debug_assertions)]
-                    let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                    let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                     callback();
                 }

--- a/src/use_intl_number_format.rs
+++ b/src/use_intl_number_format.rs
@@ -5,7 +5,7 @@ use crate::utils::js_value_from_to_string;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::fmt::Display;
 use wasm_bindgen::{JsCast, JsValue};
 

--- a/src/use_media_query.rs
+++ b/src/use_media_query.rs
@@ -4,7 +4,7 @@ use crate::use_event_listener;
 use cfg_if::cfg_if;
 use leptos::ev::change;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/use_mutation_observer.rs
+++ b/src/use_mutation_observer.rs
@@ -1,7 +1,7 @@
 use crate::core::IntoElementsMaybeSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use wasm_bindgen::prelude::*;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
@@ -88,7 +88,7 @@ where
         let closure_js = Closure::<dyn FnMut(js_sys::Array, web_sys::MutationObserver)>::new(
             move |entries: js_sys::Array, observer| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 callback(
                     entries

--- a/src/use_permission.rs
+++ b/src/use_permission.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::fmt::Display;
 
 /// Reactive [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API).
@@ -46,7 +46,7 @@ pub fn use_permission(permission_name: &str) -> Signal<PermissionState> {
             }
         };
 
-        leptos::spawn::spawn_local({
+        leptos::task::spawn_local({
             let permission_name = permission_name.to_owned();
 
             async move {

--- a/src/use_preferred_contrast.rs
+++ b/src/use_preferred_contrast.rs
@@ -1,6 +1,6 @@
 use crate::use_media_query;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::fmt::Display;
 
 /// Reactive [prefers-contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast) media query.

--- a/src/use_raf_fn.rs
+++ b/src/use_raf_fn.rs
@@ -102,7 +102,7 @@ pub fn use_raf_fn_with_options(
             };
 
             #[cfg(debug_assertions)]
-            let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             callback(UseRafFnCallbackArgs { delta, timestamp });
 

--- a/src/use_resize_observer.rs
+++ b/src/use_resize_observer.rs
@@ -1,7 +1,7 @@
 use crate::core::IntoElementsMaybeSignal;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use crate::use_supported;
@@ -89,7 +89,7 @@ where
         let closure_js = Closure::<dyn FnMut(js_sys::Array, web_sys::ResizeObserver)>::new(
             move |entries: js_sys::Array, observer| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 callback(
                     entries

--- a/src/use_scroll.rs
+++ b/src/use_scroll.rs
@@ -3,7 +3,7 @@ use crate::UseEventListenerOptions;
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::rc::Rc;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {

--- a/src/use_service_worker.rs
+++ b/src/use_service_worker.rs
@@ -1,7 +1,7 @@
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::actions::Action;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::actions::Action;
+use leptos::reactive::wrappers::read::Signal;
 use send_wrapper::SendWrapper;
 use std::sync::Arc;
 use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
@@ -54,7 +54,7 @@ pub fn use_service_worker_with_options(
         let on_controller_change = options.on_controller_change.clone();
         let js_closure = Closure::wrap(Box::new(move |_event: JsValue| {
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             on_controller_change();
         }) as Box<dyn FnMut(JsValue)>)

--- a/src/use_sorted.rs
+++ b/src/use_sorted.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::cmp::Ordering;
 use std::ops::DerefMut;
 

--- a/src/use_timeout_fn.rs
+++ b/src/use_timeout_fn.rs
@@ -94,7 +94,7 @@ where
 
                             #[cfg(debug_assertions)]
                             let _z =
-                                leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter(
+                                leptos::reactive::diagnostics::SpecialNonReactiveZone::enter(
                                 );
 
                             callback(arg);

--- a/src/use_timestamp.rs
+++ b/src/use_timestamp.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::rc::Rc;
 
 /// Reactive current timestamp.
@@ -87,7 +87,7 @@ pub fn use_timestamp_with_controls_and_options(options: UseTimestampOptions) -> 
             update();
 
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             callback(ts.get_untracked());
         }

--- a/src/use_user_media.rs
+++ b/src/use_user_media.rs
@@ -92,7 +92,7 @@ pub fn use_user_media_with_options(
     let start = move || {
         #[cfg(not(feature = "ssr"))]
         {
-            leptos::spawn::spawn_local(async move {
+            leptos::task::spawn_local(async move {
                 _start().await;
                 stream.with_untracked(move |stream| {
                     if let Some(Ok(_)) = stream {
@@ -112,7 +112,7 @@ pub fn use_user_media_with_options(
         move || enabled.get(),
         move |enabled, _, _| {
             if *enabled {
-                leptos::spawn::spawn_local(async move {
+                leptos::task::spawn_local(async move {
                     _start().await;
                 });
             } else {

--- a/src/use_web_lock.rs
+++ b/src/use_web_lock.rs
@@ -31,7 +31,7 @@ pub use web_sys::LockMode;
 ///
 /// # #[component]
 /// # fn Demo() -> impl IntoView {
-/// leptos::spawn::spawn_local(async {
+/// leptos::task::spawn_local(async {
 ///     let res = use_web_lock("my_lock", my_process).await;
 ///     assert!(matches!(res, Ok(42)));
 /// });

--- a/src/use_web_notification.rs
+++ b/src/use_web_notification.rs
@@ -2,7 +2,7 @@ use crate::{use_supported, use_window};
 use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 use std::rc::Rc;
 use wasm_bindgen::JsValue;
 
@@ -76,7 +76,7 @@ pub fn use_web_notification_with_options(
             let on_click = Rc::clone(&options.on_click);
             move |e: web_sys::Event| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 on_click(e);
             }
@@ -87,7 +87,7 @@ pub fn use_web_notification_with_options(
             let on_close = Rc::clone(&options.on_close);
             move |e: web_sys::Event| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 on_close(e);
             }
@@ -98,7 +98,7 @@ pub fn use_web_notification_with_options(
             let on_error = Rc::clone(&options.on_error);
             move |e: web_sys::Event| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 on_error(e);
             }
@@ -109,7 +109,7 @@ pub fn use_web_notification_with_options(
             let on_show = Rc::clone(&options.on_show);
             move |e: web_sys::Event| {
                 #[cfg(debug_assertions)]
-                let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 on_show(e);
             }
@@ -134,7 +134,7 @@ pub fn use_web_notification_with_options(
                 let on_error_closure = on_error_closure.clone();
                 let on_show_closure = on_show_closure.clone();
 
-                leptos::spawn::spawn_local(async move {
+                leptos::task::spawn_local(async move {
                     set_permission.set(request_web_notification_permission().await);
 
                     let mut notification_options = web_sys::NotificationOptions::from(&options);
@@ -169,7 +169,7 @@ pub fn use_web_notification_with_options(
             }
         };
 
-        leptos::spawn::spawn_local(async move {
+        leptos::task::spawn_local(async move {
             set_permission.set(request_web_notification_permission().await);
         });
 

--- a/src/use_websocket.rs
+++ b/src/use_websocket.rs
@@ -371,7 +371,7 @@ where
                         }
 
                         #[cfg(debug_assertions)]
-                        let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                        let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                         on_open(e);
 
@@ -412,7 +412,7 @@ where
                                         let txt = String::from(&txt);
 
                                         #[cfg(debug_assertions)]
-                                        let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                                        let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                                         on_message_raw(&txt);
 
@@ -422,7 +422,7 @@ where
                                         match C::decode_str(&txt) {
                                             Ok(val) => {
                                                 #[cfg(debug_assertions)]
-                                                let prev = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                                                let prev = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                                                 on_message(&val);
 
@@ -443,7 +443,7 @@ where
                                 let array = array.to_vec();
 
                                 #[cfg(debug_assertions)]
-                                let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                                let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                                 on_message_raw_bytes(&array);
 
@@ -453,7 +453,7 @@ where
                                 match C::decode_bin(array.as_slice()) {
                                     Ok(val) => {
                                         #[cfg(debug_assertions)]
-                                        let prev = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                                        let prev = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                                         on_message(&val);
 
@@ -489,7 +489,7 @@ where
                         }
 
                         #[cfg(debug_assertions)]
-                        let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                        let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                         on_error(UseWebSocketError::Event(e));
 
@@ -518,7 +518,7 @@ where
                         }
 
                         #[cfg(debug_assertions)]
-                        let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+                        let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                         on_close(e);
 

--- a/src/utils/filters/debounce.rs
+++ b/src/utils/filters/debounce.rs
@@ -52,7 +52,7 @@ where
         let last_return_val = Arc::clone(&last_return_value);
         let invoke = move || {
             #[cfg(debug_assertions)]
-            let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             let return_value = _invoke();
 

--- a/src/utils/filters/throttle.rs
+++ b/src/utils/filters/throttle.rs
@@ -58,7 +58,7 @@ where
         let last_return_val = Arc::clone(&last_return_value);
         let invoke = move || {
             #[cfg(debug_assertions)]
-            let zone = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             let return_value = _invoke();
 

--- a/src/utils/pausable.rs
+++ b/src/utils/pausable.rs
@@ -1,4 +1,4 @@
-use leptos::reactive_graph::wrappers::read::Signal;
+use leptos::reactive::wrappers::read::Signal;
 
 /// Pausable effect
 pub struct Pausable<PauseFn, ResumeFn>

--- a/src/watch_with_options.rs
+++ b/src/watch_with_options.rs
@@ -111,7 +111,7 @@ where
 
         move || {
             #[cfg(debug_assertions)]
-            let _z = leptos::reactive_graph::diagnostics::SpecialNonReactiveZone::enter();
+            let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
             let ret = callback(
                 cur_deps_value


### PR DESCRIPTION
The newest leptos version as of today's date has had some of its modules renamed, this pull request is a simple search and replace of
"reactive_graph" -> "reactive"
and
"leptos::spawn" -> "leptos::task"

The project now compiles again. All cargo tests pass except for this one:

test src/use_cookie.rs - use_cookie::use_cookie 

But I'm unsure if this is related to the newest version of leptos