### PR TITLE
Unpin `wasm-bindgen` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ paste = "1"
 send_wrapper = "0.6.0"
 thiserror = "1"
 unic-langid = { version = "0.9", optional = true }
-wasm-bindgen = "=0.2.93"
+wasm-bindgen = "0.2.95"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "=0.3.70", optional = true }
 

--- a/src/is_none.rs
+++ b/src/is_none.rs
@@ -15,7 +15,7 @@ crate::use_derive_signal!(
     ///     if js_sys::Math::random() < 0.5 { Some("Example") } else { None }
     /// );
     ///
-    /// let is_empty = is_none(example);
+    /// let is_empty = is_none::<ReadSignal<Option<&str>>, &str>(example);
     /// #
     /// # view! { }
     /// # }

--- a/src/is_some.rs
+++ b/src/is_some.rs
@@ -15,7 +15,7 @@ crate::use_derive_signal!(
     ///     if js_sys::Math::random() < 0.5 { Some("Example") } else { None }
     /// );
     ///
-    /// let not_empty = is_some(example);
+    /// let not_empty = is_some::<ReadSignal<Option<&str>>, &str>(example);
     /// #
     /// # view! { }
     /// # }

--- a/src/sync_signal.rs
+++ b/src/sync_signal.rs
@@ -18,6 +18,7 @@ use std::rc::Rc;
 ///
 /// ```
 /// # use leptos::prelude::*;
+/// # use leptos::logging::log;
 /// # use leptos_use::sync_signal;
 /// #
 /// # #[component]
@@ -71,6 +72,7 @@ use std::rc::Rc;
 ///
 /// ```
 /// # use leptos::prelude::*;
+/// # use leptos::logging::log;
 /// # use leptos_use::{sync_signal_with_options, SyncSignalOptions, SyncDirection};
 /// #
 /// # #[component]
@@ -102,6 +104,7 @@ use std::rc::Rc;
 ///
 /// ```
 /// # use leptos::prelude::*;
+/// # use leptos::logging::log;
 /// # use leptos_use::{sync_signal_with_options, SyncSignalOptions};
 /// #
 /// # #[component]

--- a/src/use_active_element.rs
+++ b/src/use_active_element.rs
@@ -15,6 +15,7 @@ use leptos::reactive::wrappers::read::Signal;
 ///
 /// ```
 /// # use leptos::prelude::*;
+/// # use leptos::logging::log;
 /// # use leptos_use::use_active_element;
 /// #
 /// # #[component]

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -7,7 +7,7 @@ use cookie::time::{Duration, OffsetDateTime};
 pub use cookie::SameSite;
 use cookie::{Cookie, CookieJar};
 use default_struct_builder::DefaultBuilder;
-use leptos::prelude::*;
+use leptos::{logging::{debug_warn, error}, prelude::*};
 use std::sync::Arc;
 
 /// SSR-friendly and reactive cookie access.

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -8,7 +8,7 @@ pub use cookie::SameSite;
 use cookie::{Cookie, CookieJar};
 use default_struct_builder::DefaultBuilder;
 use leptos::{
-    logging::{debug_warn, error, warn},
+    logging::{debug_warn, error},
     prelude::*,
 };
 use std::sync::Arc;
@@ -537,6 +537,7 @@ impl<T, E, D> Default for UseCookieOptions<T, E, D> {
                         not(feature = "spin")
                     ))]
                     {
+                        use leptos::logging::warn;
                         let _ = cookie;
                         warn!("If you're using use_cookie without the feature `axum`, `actix` or `spin` enabled, you should provide the option `ssr_set_cookie`");
                     }

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -7,7 +7,10 @@ use cookie::time::{Duration, OffsetDateTime};
 pub use cookie::SameSite;
 use cookie::{Cookie, CookieJar};
 use default_struct_builder::DefaultBuilder;
-use leptos::{logging::{debug_warn, error}, prelude::*};
+use leptos::{
+    logging::{debug_warn, error, warn},
+    prelude::*,
+};
 use std::sync::Arc;
 
 /// SSR-friendly and reactive cookie access.

--- a/src/use_display_media.rs
+++ b/src/use_display_media.rs
@@ -15,6 +15,7 @@ use wasm_bindgen::{JsCast, JsValue};
 ///
 /// ```
 /// # use leptos::prelude::*;
+/// # use leptos::logging::{log, error};
 /// # use leptos_use::{use_display_media, UseDisplayMediaReturn};
 /// #
 /// # #[component]

--- a/src/use_service_worker.rs
+++ b/src/use_service_worker.rs
@@ -1,5 +1,5 @@
 use default_struct_builder::DefaultBuilder;
-use leptos::prelude::*;
+use leptos::{logging::{warn, debug_warn}, prelude::*};
 use leptos::reactive::actions::Action;
 use leptos::reactive::wrappers::read::Signal;
 use send_wrapper::SendWrapper;

--- a/src/use_service_worker.rs
+++ b/src/use_service_worker.rs
@@ -1,7 +1,10 @@
 use default_struct_builder::DefaultBuilder;
-use leptos::{logging::{warn, debug_warn}, prelude::*};
 use leptos::reactive::actions::Action;
 use leptos::reactive::wrappers::read::Signal;
+use leptos::{
+    logging::{debug_warn, warn},
+    prelude::*,
+};
 use send_wrapper::SendWrapper;
 use std::sync::Arc;
 use wasm_bindgen::{prelude::Closure, JsCast, JsValue};

--- a/src/use_user_media.rs
+++ b/src/use_user_media.rs
@@ -14,6 +14,7 @@ use wasm_bindgen::{JsCast, JsValue};
 ///
 /// ```
 /// # use leptos::prelude::*;
+/// # use leptos::logging::{log, error};
 /// # use leptos_use::{use_user_media, UseUserMediaReturn};
 /// #
 /// # #[component]


### PR DESCRIPTION
Unpin `wasm-bingen` to be compatible with `leptos-0.7.0-rc1`. See https://github.com/leptos-rs/leptos/pull/3186.

Fixes https://github.com/Synphonyte/leptos-use/issues/176