### PR TITLE
Fix MediaTrackConstraints dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,6 +350,7 @@ use_user_media = [
     "web-sys/MediaStream",
     "web-sys/MediaStreamConstraints",
     "web-sys/MediaStreamTrack",
+    "web-sys/MediaTrackConstraints",
     "web-sys/VideoFacingModeEnum",
 ]
 use_web_notification = [
@@ -360,7 +361,6 @@ use_web_notification = [
     "web-sys/NotificationOptions",
     "web-sys/NotificationPermission",
     "web-sys/NotificationDirection",
-    "web-sys/MediaTrackConstraints",
     "web-sys/VisibilityState"
 ]
 use_websocket = ["dep:web-sys", "dep:codee"]


### PR DESCRIPTION
After  #183 (Thanks, BTW!), the crate does not build with `--no-default-features --features use_user_media`. It looks like the `web-sys/MediaTrackConstraints` dependency accidentally ended up in the `use_web_notification` feature block. I swapped it to `use_user_media` block and tested with:

```shell
cargo build --no-default-features --features use_user_media && \
cargo build --no-default-features --features use_web_notification
```