### PR TITLE
Fix Clippy Warnings for Leptos 0.7

### DIFF
--- a/src/docs/boolean_display.rs
+++ b/src/docs/boolean_display.rs
@@ -2,7 +2,7 @@ use leptos::prelude::*;
 
 #[component]
 pub fn BooleanDisplay(
-    #[prop(into)] value: MaybeSignal<bool>,
+    #[prop(into)] value: Signal<bool>,
     #[prop(optional, into)] class: String,
     #[prop(default = "true")] true_str: &'static str,
     #[prop(default = "false")] false_str: &'static str,

--- a/src/math/shared.rs
+++ b/src/math/shared.rs
@@ -47,7 +47,7 @@ macro_rules! use_simple_math {
             $(#[$outer])*
             pub fn [<use_ $fn_name>]<S, N>(x: S) -> Signal<N>
             where
-                S: Into<MaybeSignal<N>> + Send + Sync,
+                S: Into<Signal<N>> + Send + Sync,
                 N: Float + Send + Sync + 'static,
             {
                 let x = x.into();
@@ -67,8 +67,8 @@ macro_rules! use_binary_logic {
             $(#[$outer])*
             pub fn [<use_ $fn_name>]<S1, S2>(a: S1, b: S2) -> Signal<bool>
             where
-                S1: Into<MaybeSignal<bool>>,
-                S2: Into<MaybeSignal<bool>>,
+                S1: Into<Signal<bool>>,
+                S2: Into<Signal<bool>>,
             {
                 let a = a.into();
                 let b = b.into();

--- a/src/math/use_not.rs
+++ b/src/math/use_not.rs
@@ -31,7 +31,7 @@ use leptos::reactive::wrappers::read::Signal;
 // #[doc(cfg(feature = "math"))]
 pub fn use_not<S>(a: S) -> Signal<bool>
 where
-    S: Into<MaybeSignal<bool>>,
+    S: Into<Signal<bool>>,
 {
     let a = a.into();
     Signal::derive(move || !a.get())

--- a/src/use_css_var.rs
+++ b/src/use_css_var.rs
@@ -77,9 +77,7 @@ use wasm_bindgen::JsCast;
 /// ## Server-Side Rendering
 ///
 /// On the server this simply returns `signal(options.initial_value)`.
-pub fn use_css_var(
-    prop: impl Into<MaybeSignal<String>>,
-) -> (ReadSignal<String>, WriteSignal<String>) {
+pub fn use_css_var(prop: impl Into<Signal<String>>) -> (ReadSignal<String>, WriteSignal<String>) {
     use_css_var_with_options(prop, UseCssVarOptions::default())
 }
 
@@ -89,7 +87,7 @@ pub fn use_css_var_with_options<P, El, M>(
     options: UseCssVarOptions<El, M>,
 ) -> (ReadSignal<String>, WriteSignal<String>)
 where
-    P: Into<MaybeSignal<String>>,
+    P: Into<Signal<String>>,
     El: Clone,
     El: IntoElementMaybeSignal<web_sys::Element, M>,
 {

--- a/src/use_css_var.rs
+++ b/src/use_css_var.rs
@@ -106,15 +106,12 @@ where
         let prop = prop.into();
 
         let update_css_var = {
-            let prop = prop.clone();
             let el_signal = el_signal.clone();
 
             move || {
-                let key = prop.get_untracked();
-
                 if let Some(el) = el_signal.get_untracked() {
                     if let Ok(Some(style)) = window().get_computed_style(&el) {
-                        if let Ok(value) = style.get_property_value(&key) {
+                        if let Ok(value) = style.get_property_value(&prop.read_untracked()) {
                             set_variable.update(|var| *var = value.trim().to_string());
                             return;
                         }
@@ -142,7 +139,6 @@ where
 
         {
             let el_signal = el_signal.clone();
-            let prop = prop.clone();
 
             let _ = watch_with_options(
                 move || (el_signal.get(), prop.get()),

--- a/src/use_cycle_list.rs
+++ b/src/use_cycle_list.rs
@@ -83,80 +83,49 @@ where
 
     let (state, set_state) = get_initial_value().into_signal();
 
-    let index = {
-        let list = list.clone();
+    let index = Signal::derive(move || {
+        let index = get_position(&state.get(), &list.read());
 
-        Signal::derive(move || {
-            list.with(|list| {
-                let index = get_position(&state.get(), list);
-
-                if let Some(index) = index {
-                    index
-                } else {
-                    fallback_index
-                }
-            })
-        })
-    };
-
-    let set = {
-        let list = list.clone();
-
-        move |i: usize| {
-            list.with(|list| {
-                let length = list.len();
-
-                let index = i % length;
-                let value = list[index].clone();
-
-                set_state.update({
-                    let value = value.clone();
-
-                    move |v| *v = value
-                });
-
-                value
-            })
+        if let Some(index) = index {
+            index
+        } else {
+            fallback_index
         }
+    });
+
+    let set = move |i: usize| {
+        let length = list.read().len();
+
+        let index = i % length;
+        let value = list.read()[index].clone();
+
+        set_state.update({
+            let value = value.clone();
+
+            move |v| *v = value
+        });
+
+        value
     };
 
-    let shift = {
-        let list = list.clone();
-        let set = set.clone();
+    let shift = move |delta: i64| {
+        let length = list.read().len() as i64;
 
-        move |delta: i64| {
-            let index = list.with(|list| {
-                let length = list.len() as i64;
+        let i = index.get_untracked() as i64 + delta;
+        let index = (i % length) + length;
 
-                let i = index.get_untracked() as i64 + delta;
-                (i % length) + length
-            });
-
-            set(index as usize)
-        }
+        set(index as usize)
     };
 
-    let next = {
-        let shift = shift.clone();
-
-        move || {
-            shift(1);
-        }
+    let next = move || {
+        shift(1);
     };
 
-    let prev = {
-        let shift = shift.clone();
-
-        move || {
-            shift(-1);
-        }
+    let prev = move || {
+        shift(-1);
     };
 
-    let _ = {
-        let set = set.clone();
-
-        Effect::watch(move || list.get(), move |_, _, _| set(index.get()), false)
-    };
+    let _ = Effect::watch(move || list.get(), move |_, _, _| set(index.get()), false);
 
     UseCycleListReturn {
         state,

--- a/src/use_cycle_list.rs
+++ b/src/use_cycle_list.rs
@@ -41,7 +41,7 @@ pub fn use_cycle_list<T, L>(
 >
 where
     T: Clone + PartialEq + Send + Sync + 'static,
-    L: Into<MaybeSignal<Vec<T>>>,
+    L: Into<Signal<Vec<T>>>,
 {
     use_cycle_list_with_options(list, UseCycleListOptions::default())
 }
@@ -58,7 +58,7 @@ pub fn use_cycle_list_with_options<T, L>(
 >
 where
     T: Clone + PartialEq + Send + Sync + 'static,
-    L: Into<MaybeSignal<Vec<T>>>,
+    L: Into<Signal<Vec<T>>>,
 {
     let UseCycleListOptions {
         initial_value,

--- a/src/use_debounce_fn.rs
+++ b/src/use_debounce_fn.rs
@@ -1,6 +1,6 @@
 pub use crate::utils::DebounceOptions;
 use crate::utils::{create_filter_wrapper, create_filter_wrapper_with_arg, debounce_filter};
-use leptos::prelude::MaybeSignal;
+use leptos::prelude::Signal;
 use std::sync::{Arc, Mutex};
 
 /// Debounce execution of a function.
@@ -75,7 +75,7 @@ use std::sync::{Arc, Mutex};
 /// a debounced function on the server will simply be ignored.
 pub fn use_debounce_fn<F, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
 ) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn() -> R + Clone + 'static,
@@ -87,7 +87,7 @@ where
 /// Version of [`use_debounce_fn`] with debounce options. See the docs for [`use_debounce_fn`] for how to use.
 pub fn use_debounce_fn_with_options<F, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
     options: DebounceOptions,
 ) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
@@ -100,7 +100,7 @@ where
 /// Version of [`use_debounce_fn`] with an argument for the debounced function. See the docs for [`use_debounce_fn`] for how to use.
 pub fn use_debounce_fn_with_arg<F, Arg, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
 ) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn(Arg) -> R + Clone + 'static,
@@ -113,7 +113,7 @@ where
 /// Version of [`use_debounce_fn_with_arg`] with debounce options.
 pub fn use_debounce_fn_with_arg_and_options<F, Arg, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
     options: DebounceOptions,
 ) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where

--- a/src/use_draggable.rs
+++ b/src/use_draggable.rs
@@ -241,15 +241,15 @@ where
 {
     /// Only start the dragging when click on the element directly. Defaults to `false`.
     #[builder(into)]
-    exact: MaybeSignal<bool>,
+    exact: Signal<bool>,
 
     /// Prevent events defaults. Defaults to `false`.
     #[builder(into)]
-    prevent_default: MaybeSignal<bool>,
+    prevent_default: Signal<bool>,
 
     /// Prevent events propagation. Defaults to `false`.
     #[builder(into)]
-    stop_propagation: MaybeSignal<bool>,
+    stop_propagation: Signal<bool>,
 
     /// Element to attach `pointermove` and `pointerup` events to. Defaults to `window`.
     dragging_element: DragEl,
@@ -287,9 +287,9 @@ where
 {
     fn default() -> Self {
         Self {
-            exact: MaybeSignal::default(),
-            prevent_default: MaybeSignal::default(),
-            stop_propagation: MaybeSignal::default(),
+            exact: Signal::default(),
+            prevent_default: Signal::default(),
+            stop_propagation: Signal::default(),
             dragging_element: use_window(),
             handle: None,
             pointer_types: vec![PointerType::Mouse, PointerType::Touch, PointerType::Pen],

--- a/src/use_interval.rs
+++ b/src/use_interval.rs
@@ -37,7 +37,7 @@ pub fn use_interval<N>(
     interval: N,
 ) -> UseIntervalReturn<impl Fn() + Clone, impl Fn() + Clone, impl Fn() + Clone>
 where
-    N: Into<MaybeSignal<u64>>,
+    N: Into<Signal<u64>>,
 {
     use_interval_with_options(interval, UseIntervalOptions::default())
 }
@@ -48,7 +48,7 @@ pub fn use_interval_with_options<N>(
     options: UseIntervalOptions,
 ) -> UseIntervalReturn<impl Fn() + Clone, impl Fn() + Clone, impl Fn() + Clone>
 where
-    N: Into<MaybeSignal<u64>>,
+    N: Into<Signal<u64>>,
 {
     let UseIntervalOptions {
         immediate,

--- a/src/use_interval_fn.rs
+++ b/src/use_interval_fn.rs
@@ -43,7 +43,7 @@ pub fn use_interval_fn<CbFn, N>(
 ) -> Pausable<impl Fn() + Clone + Send + Sync, impl Fn() + Clone + Send + Sync>
 where
     CbFn: Fn() + Clone + 'static + Send + Sync,
-    N: Into<MaybeSignal<u64>>,
+    N: Into<Signal<u64>>,
 {
     use_interval_fn_with_options(callback, interval, UseIntervalFnOptions::default())
 }
@@ -56,7 +56,7 @@ pub fn use_interval_fn_with_options<CbFn, N>(
 ) -> Pausable<impl Fn() + Clone, impl Fn() + Clone>
 where
     CbFn: Fn() + Clone + 'static,
-    N: Into<MaybeSignal<u64>>,
+    N: Into<Signal<u64>>,
 {
     let UseIntervalFnOptions {
         immediate,
@@ -126,7 +126,7 @@ where
         resume();
     }
 
-    if matches!(interval, MaybeSignal::Dynamic(_)) {
+    {
         #[allow(clippy::clone_on_copy)]
         let resume = resume.clone();
 

--- a/src/use_intl_number_format.rs
+++ b/src/use_intl_number_format.rs
@@ -610,7 +610,7 @@ pub struct UseIntlNumberFormatOptions {
     ///         .style(NumberStyle::Currency)
     ///         .currency("USD")
     ///         .maximum_fraction_digits(2)
-    ///         .rounding_increment(5),    
+    ///         .rounding_increment(5),
     /// );
     ///
     /// let formatted = nf.format(11.29); // "$11.30"
@@ -775,7 +775,7 @@ cfg_if! { if #[cfg(feature = "ssr")] {
 impl UseIntlNumberFormatReturn {
     /// Formats a number according to the [locale and formatting options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters) of this `Intl.NumberFormat` object.
     /// See [`use_intl_number_format`] for more information.
-    pub fn format<N>(&self, number: impl Into<MaybeSignal<N>>) -> Signal<String, LocalStorage>
+    pub fn format<N>(&self, number: impl Into<Signal<N>>) -> Signal<String, LocalStorage>
     where
         N: Clone + Display + Send + Sync + 'static,
         js_sys::Number: From<N>,
@@ -850,8 +850,8 @@ impl UseIntlNumberFormatReturn {
     /// ```
     pub fn format_range<NStart, NEnd>(
         &self,
-        start: impl Into<MaybeSignal<NStart>>,
-        end: impl Into<MaybeSignal<NEnd>>,
+        start: impl Into<Signal<NStart>>,
+        end: impl Into<Signal<NEnd>>,
     ) -> Signal<String, LocalStorage>
     where
         NStart: Clone + Display + Send + Sync + 'static,
@@ -891,7 +891,7 @@ impl UseIntlNumberFormatReturn {
     // pub fn format_to_parts<N>(
     //     &self,
     //     ,
-    //     number: impl Into<MaybeSignal<N>>,
+    //     number: impl Into<Signal<N>>,
     // ) -> Signal<Vec<String>>
     // where
     //     N: Clone + 'static,

--- a/src/use_media_query.rs
+++ b/src/use_media_query.rs
@@ -40,7 +40,7 @@ use std::rc::Rc;
 /// * [`fn@crate::use_preferred_dark`]
 /// * [`fn@crate::use_preferred_contrast`]
 /// * [`fn@crate::use_prefers_reduced_motion`]
-pub fn use_media_query(query: impl Into<MaybeSignal<String>>) -> Signal<bool> {
+pub fn use_media_query(query: impl Into<Signal<String>>) -> Signal<bool> {
     let query = query.into();
 
     let (matches, set_matches) = signal(false);

--- a/src/use_scroll.rs
+++ b/src/use_scroll.rs
@@ -470,7 +470,7 @@ pub struct UseScrollOptions {
     /// When changing the `x` or `y` signals this specifies the scroll behaviour.
     /// Can be `Auto` (= not smooth) or `Smooth`. Defaults to `Auto`.
     #[builder(into)]
-    behavior: MaybeSignal<ScrollBehavior>,
+    behavior: Signal<ScrollBehavior>,
 }
 
 impl Default for UseScrollOptions {

--- a/src/use_sorted.rs
+++ b/src/use_sorted.rs
@@ -76,7 +76,7 @@ use std::ops::DerefMut;
 /// Please note that these two ways of sorting are equivalent.
 pub fn use_sorted<S, I, T>(iterable: S) -> Signal<I>
 where
-    S: Into<MaybeSignal<I>>,
+    S: Into<Signal<I>>,
     T: Ord,
     I: DerefMut<Target = [T]> + Clone + PartialEq + Send + Sync + 'static,
 {
@@ -92,7 +92,7 @@ where
 /// Version of [`use_sorted`] with a compare function.
 pub fn use_sorted_by<S, I, T, F>(iterable: S, cmp_fn: F) -> Signal<I>
 where
-    S: Into<MaybeSignal<I>>,
+    S: Into<Signal<I>>,
     I: DerefMut<Target = [T]> + Clone + PartialEq + Send + Sync + 'static,
     F: FnMut(&T, &T) -> Ordering + Clone + Send + Sync + 'static,
 {
@@ -108,7 +108,7 @@ where
 /// Version of [`use_sorted`] by key.
 pub fn use_sorted_by_key<S, I, T, K, F>(iterable: S, key_fn: F) -> Signal<I>
 where
-    S: Into<MaybeSignal<I>>,
+    S: Into<Signal<I>>,
     I: DerefMut<Target = [T]> + Clone + PartialEq + Send + Sync + 'static,
     K: Ord,
     F: FnMut(&T) -> K + Clone + Send + Sync + 'static,

--- a/src/use_throttle_fn.rs
+++ b/src/use_throttle_fn.rs
@@ -1,5 +1,5 @@
 use crate::utils::{create_filter_wrapper, create_filter_wrapper_with_arg, throttle_filter};
-use leptos::prelude::MaybeSignal;
+use leptos::prelude::Signal;
 use std::sync::{Arc, Mutex};
 
 pub use crate::utils::ThrottleOptions;
@@ -71,7 +71,7 @@ pub use crate::utils::ThrottleOptions;
 /// a throttled function on the server will simply be ignored.
 pub fn use_throttle_fn<F, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
 ) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn() -> R + Clone + 'static,
@@ -83,7 +83,7 @@ where
 /// Version of [`use_throttle_fn`] with throttle options. See the docs for [`use_throttle_fn`] for how to use.
 pub fn use_throttle_fn_with_options<F, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
     options: ThrottleOptions,
 ) -> impl Fn() -> Arc<Mutex<Option<R>>> + Clone
 where
@@ -96,7 +96,7 @@ where
 /// Version of [`use_throttle_fn`] with an argument for the throttled function. See the docs for [`use_throttle_fn`] for how to use.
 pub fn use_throttle_fn_with_arg<F, Arg, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
 ) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where
     F: Fn(Arg) -> R + Clone + 'static,
@@ -109,7 +109,7 @@ where
 /// Version of [`use_throttle_fn_with_arg`] with throttle options. See the docs for [`use_throttle_fn`] for how to use.
 pub fn use_throttle_fn_with_arg_and_options<F, Arg, R>(
     func: F,
-    ms: impl Into<MaybeSignal<f64>> + 'static,
+    ms: impl Into<Signal<f64>> + 'static,
     options: ThrottleOptions,
 ) -> impl Fn(Arg) -> Arc<Mutex<Option<R>>> + Clone
 where

--- a/src/use_timeout_fn.rs
+++ b/src/use_timeout_fn.rs
@@ -39,7 +39,7 @@ pub fn use_timeout_fn<CbFn, Arg, D>(
 where
     CbFn: Fn(Arg) + Clone + 'static,
     Arg: 'static,
-    D: Into<MaybeSignal<f64>>,
+    D: Into<Signal<f64>>,
 {
     let delay = delay.into();
 

--- a/src/use_websocket.rs
+++ b/src/use_websocket.rs
@@ -657,7 +657,7 @@ where
     /// Note that protocols are only updated on the next websocket open() call, not whenever the signal is updated.
     /// Therefore "lazy" protocols should use the `immediate(false)` option and manually call `open()`.
     #[builder(into)]
-    protocols: MaybeSignal<Option<Vec<String>>>,
+    protocols: Signal<Option<Vec<String>>>,
 }
 
 impl<Rx: ?Sized, E, D> UseWebSocketOptions<Rx, E, D> {

--- a/src/utils/filters/debounce.rs
+++ b/src/utils/filters/debounce.rs
@@ -12,11 +12,11 @@ pub struct DebounceOptions {
     /// The maximum time allowed to be delayed before it's invoked.
     /// In milliseconds.
     #[builder(into)]
-    pub max_wait: MaybeSignal<Option<f64>>,
+    pub max_wait: Signal<Option<f64>>,
 }
 
 pub fn debounce_filter<R>(
-    ms: impl Into<MaybeSignal<f64>>,
+    ms: impl Into<Signal<f64>>,
     options: DebounceOptions,
 ) -> impl Fn(Arc<dyn Fn() -> R>) -> Arc<Mutex<Option<R>>> + Clone
 where

--- a/src/utils/filters/mod.rs
+++ b/src/utils/filters/mod.rs
@@ -4,7 +4,7 @@ mod throttle;
 pub use debounce::*;
 pub use throttle::*;
 
-use leptos::prelude::MaybeSignal;
+use leptos::prelude::Signal;
 use std::sync::{Arc, Mutex};
 
 macro_rules! ArcFilterFn {
@@ -45,24 +45,24 @@ pub enum FilterOptions {
     #[default]
     None,
     Debounce {
-        ms: MaybeSignal<f64>,
+        ms: Signal<f64>,
         options: DebounceOptions,
     },
     Throttle {
-        ms: MaybeSignal<f64>,
+        ms: Signal<f64>,
         options: ThrottleOptions,
     },
 }
 
 impl FilterOptions {
-    pub fn debounce(ms: impl Into<MaybeSignal<f64>>) -> Self {
+    pub fn debounce(ms: impl Into<Signal<f64>>) -> Self {
         Self::Debounce {
             ms: ms.into(),
             options: DebounceOptions::default(),
         }
     }
 
-    pub fn throttle(ms: impl Into<MaybeSignal<f64>>) -> Self {
+    pub fn throttle(ms: impl Into<Signal<f64>>) -> Self {
         Self::Throttle {
             ms: ms.into(),
             options: ThrottleOptions::default(),
@@ -93,7 +93,7 @@ macro_rules! filter_builder_methods {
         /// Debounce
         #[$filter_docs]
         /// by `ms` milliseconds.
-        pub fn debounce(self, ms: impl Into<MaybeSignal<f64>>) -> Self {
+        pub fn debounce(self, ms: impl Into<Signal<f64>>) -> Self {
             self.debounce_with_options(ms, DebounceOptions::default())
         }
 
@@ -102,7 +102,7 @@ macro_rules! filter_builder_methods {
         /// by `ms` milliseconds with additional options.
         pub fn debounce_with_options(
             self,
-            ms: impl Into<MaybeSignal<f64>>,
+            ms: impl Into<Signal<f64>>,
             options: DebounceOptions,
         ) -> Self {
             Self {
@@ -117,7 +117,7 @@ macro_rules! filter_builder_methods {
         /// Throttle
         #[$filter_docs]
         /// by `ms` milliseconds.
-        pub fn throttle(self, ms: impl Into<MaybeSignal<f64>>) -> Self {
+        pub fn throttle(self, ms: impl Into<Signal<f64>>) -> Self {
             self.throttle_with_options(ms, ThrottleOptions::default())
         }
 
@@ -126,7 +126,7 @@ macro_rules! filter_builder_methods {
         /// by `ms` milliseconds with additional options.
         pub fn throttle_with_options(
             self,
-            ms: impl Into<MaybeSignal<f64>>,
+            ms: impl Into<Signal<f64>>,
             options: ThrottleOptions,
         ) -> Self {
             Self {

--- a/src/utils/filters/throttle.rs
+++ b/src/utils/filters/throttle.rs
@@ -27,7 +27,7 @@ impl Default for ThrottleOptions {
 }
 
 pub fn throttle_filter<R>(
-    ms: impl Into<MaybeSignal<f64>>,
+    ms: impl Into<Signal<f64>>,
     options: ThrottleOptions,
 ) -> impl Fn(Arc<dyn Fn() -> R>) -> Arc<Mutex<Option<R>>> + Clone
 where

--- a/src/utils/signal_filtered.rs
+++ b/src/utils/signal_filtered.rs
@@ -13,7 +13,7 @@ macro_rules! signal_filtered {
             #[track_caller]
             pub fn [<signal_ $filter_name d>]<S, T>(
                 value: S,
-                ms: impl Into<MaybeSignal<f64>> + 'static,
+                ms: impl Into<Signal<f64>> + 'static,
             ) -> Signal<T>
             where
                 S: Into<Signal<T>>,
@@ -33,7 +33,7 @@ macro_rules! signal_filtered {
             #[track_caller]
             pub fn [<signal_ $filter_name d_with_options>]<S, T>(
                 value: S,
-                ms: impl Into<MaybeSignal<f64>> + 'static,
+                ms: impl Into<Signal<f64>> + 'static,
                 options: [<$filter_name:camel Options>],
             ) -> Signal<T>
             where

--- a/src/watch_debounced.rs
+++ b/src/watch_debounced.rs
@@ -117,5 +117,5 @@ pub struct WatchDebouncedOptions {
     /// In milliseconds.
     /// Same as [`DebounceOptions::max_wait`]
     #[builder(into)]
-    pub max_wait: MaybeSignal<Option<f64>>,
+    pub max_wait: Signal<Option<f64>>,
 }


### PR DESCRIPTION
I was taking a look at this project and kept getting a bunch of warnings when I ran `cargo check`. This PR fixes all the warnings from running `cargo check` and `cargo clippy`.