### PR TITLE
fix: unpinning web-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1"
 unic-langid = { version = "0.9", optional = true }
 wasm-bindgen = "0.2.95"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "=0.3.70", optional = true }
+web-sys = { version = "0.3.72", optional = true }
 
 [dev-dependencies]
 codee = { version = "0.2", features = [


### PR DESCRIPTION
This PR unpins the `web-sys` crate version to be in sync with `leptos`.