### PR TITLE
Prevent crashes on `use_locale`

### DIFF
--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -69,7 +69,7 @@ where
             // Checked it's not empty above.
             let first_supported = *supported_iter.peek().unwrap();
 
-            for ref s in supported_iter {
+            for s in supported_iter {
                 for client_locale in client_locales {
                     let client_locale = client_locale.parse::<LanguageIdentifier>();
 

--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -1,5 +1,5 @@
 use crate::{use_locales_with_options, UseLocalesOptions};
-use leptos::prelude::*;
+use leptos::{logging::warn, prelude::*};
 use unic_langid::LanguageIdentifier;
 
 /// Reactive locale matching.
@@ -63,27 +63,27 @@ where
     assert!(!supported.is_empty(), "{}", EMPTY_ERR_MSG);
 
     Signal::derive(move || {
-        let supported = supported.clone();
-
         client_locales.with(|client_locales| {
-            let mut first_supported = None;
+            let mut supported_iter = supported.iter().peekable();
 
-            for s in supported {
-                if first_supported.is_none() {
-                    first_supported = Some(s.clone());
-                }
+            // Checked it's not empty above.
+            let first_supported = *supported_iter.peek().unwrap();
 
+            for ref s in supported_iter {
                 for client_locale in client_locales {
-                    let client_locale: LanguageIdentifier = client_locale
-                        .parse()
-                        .expect("Client should provide a list of valid unicode locales");
-                    if client_locale.matches(&s, true, true) {
-                        return s;
+                    let client_locale = client_locale.parse::<LanguageIdentifier>();
+
+                    if let Ok(client_locale) = client_locale {
+                        if client_locale.matches(s, true, true) {
+                            return (*s).clone();
+                        }
+                    } else {
+                        warn!("Received an invalid LanguageIdentifier")
                     }
                 }
             }
 
-            unreachable!("{}", EMPTY_ERR_MSG);
+            (*first_supported).clone()
         })
     })
 }


### PR DESCRIPTION
Currently, on `use_locale`, if the server receives a malformed `Accept-Language` header, it will panic: <https://github.com/Synphonyte/leptos-use/blob/a1bac85023e26a3079a19657d687e27cfadfeeed/src/use_locale.rs#L79>

Changed it so the offending language (or the entire header, see `use_locales`) is ignored and a warning is logged instead.

The current implementation will also panic if there are no client languages whatsoever. Fixed that case too.

I tried to do it in such a way as to minimize clones.