### PR TITLE
Fix order of language checks in `use_locale`

### DIFF
--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -69,7 +69,7 @@ where
             // Checked it's not empty above.
             let first_supported = *supported_iter.peek().unwrap();
 
-            for ref s in supported_iter {
+            for s in supported_iter {
                 for client_locale in client_locales {
                     let client_locale = client_locale.parse::<LanguageIdentifier>();
 

--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -69,8 +69,10 @@ where
             // Checked it's not empty above.
             let first_supported = *supported_iter.peek().unwrap();
 
-            for s in supported_iter {
-                for client_locale in client_locales {
+            for client_locale in client_locales {
+                let supported_iter = supported_iter.clone();
+
+                for s in supported_iter {
                     let client_locale = client_locale.parse::<LanguageIdentifier>();
 
                     if let Ok(client_locale) = client_locale {

--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -1,5 +1,5 @@
 use crate::{use_locales_with_options, UseLocalesOptions};
-use leptos::prelude::*;
+use leptos::{logging::warn, prelude::*};
 use unic_langid::LanguageIdentifier;
 
 /// Reactive locale matching.
@@ -63,27 +63,27 @@ where
     assert!(!supported.is_empty(), "{}", EMPTY_ERR_MSG);
 
     Signal::derive(move || {
-        let supported = supported.clone();
-
         client_locales.with(|client_locales| {
-            let mut first_supported = None;
+            let mut supported_iter = supported.iter().peekable();
 
-            for s in supported {
-                if first_supported.is_none() {
-                    first_supported = Some(s.clone());
-                }
+            // Checked it's not empty above.
+            let first_supported = *supported_iter.peek().unwrap();
 
+            for ref s in supported_iter {
                 for client_locale in client_locales {
-                    let client_locale: LanguageIdentifier = client_locale
-                        .parse()
-                        .expect("Client should provide a list of valid unicode locales");
-                    if client_locale.matches(&s, true, true) {
-                        return s;
+                    let client_locale = client_locale.parse::<LanguageIdentifier>();
+
+                    if let Ok(client_locale) = client_locale {
+                        if client_locale.matches(s, true, true) {
+                            return (*s).clone();
+                        }
+                    } else {
+                        warn!("Received an invalid LanguageIdentifier")
                     }
                 }
             }
 
-            unreachable!("{}", EMPTY_ERR_MSG);
+            (*first_supported).clone()
         })
     })
 }


### PR DESCRIPTION
This builds upon #199, because the code overlaps.

Currently, the matching algorithm does it best to try to match the first _supported_ languages, instead of prioritizing matching the first _client_ languages, which would be the more useful behavior.

So, for example, if the user declares it accepts Chinese first, English second; but the application support English first, Chinese second; then, the first supported language, English, will be matched, even though the user would prefer Chinese.

This change inverts the order in which the languages are checked so that the supported languages are exhausted before moving to the next client one.

I'm assuming the `clone` on the Peekable iterator is cheap, but honestly I'm not entirely sure.