### PR TITLE
Update to stable Leptos 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Updated Leptos to use stable 0.7 version
+- Updated wasm-bindgen to 0.2.96
+- Updated web-sys 0.3.73
+
 ## [0.14.0-rc5] - 2024-11-27
 
 - fixed error messages for get_header

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,18 +26,18 @@ http1 = { version = "1", optional = true, package = "http" }
 http0_2 = { version = "0.2", optional = true, package = "http" }
 js-sys = "0.3"
 lazy_static = "1"
-leptos = "0.7.0-rc2"
-leptos_axum = { version = "0.7.0-rc2", default-features = false, optional = true }
-leptos_actix = { version = "0.7.0-rc2", default-features = false, optional = true }
+leptos = "0.7"
+leptos_axum = { version = "0.7", default-features = false, optional = true }
+leptos_actix = { version = "0.7", default-features = false, optional = true }
 leptos-spin = { version = "0.2", default-features = false, optional = true }
 num = { version = "0.4", optional = true }
 paste = "1"
 send_wrapper = "0.6.0"
 thiserror = "2"
 unic-langid = { version = "0.9", optional = true }
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.96"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3.72", optional = true }
+web-sys = { version = "0.3.73", optional = true }
 
 [dev-dependencies]
 codee = { version = "0.2", features = [
@@ -47,7 +47,7 @@ codee = { version = "0.2", features = [
     "prost",
 ] }
 getrandom = { version = "0.2", features = ["js"] }
-leptos_meta = { version = "0.7.0-rc2" }
+leptos_meta = "0.7"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 unic-langid = { version = "0.9", features = ["macros"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -76,7 +76,7 @@ members = [
 exclude = ["ssr", "use_webtransport_with_server"]
 
 [workspace.dependencies]
-leptos = "0.7.0-rc2"
+leptos = "0.7"
 codee = "0.2"
 console_error_panic_hook = "0.1"
 console_log = "1"

--- a/examples/ssr/Cargo.toml
+++ b/examples/ssr/Cargo.toml
@@ -12,10 +12,10 @@ codee = "0.2"
 console_error_panic_hook = "0.1"
 console_log = "1"
 cfg-if = "1"
-leptos = { version = "0.7.0-rc2", features = ["nightly"] }
-leptos_axum = { version = "0.7.0-rc2", optional = true }
-leptos_meta = "0.7.0-rc2"
-leptos_router = { version = "0.7.0-rc2", features = [
+leptos = { version = "0.7", features = ["nightly"] }
+leptos_axum = { version = "0.7", optional = true }
+leptos_meta = "0.7"
+leptos_router = { version = "0.7", features = [
     "nightly",
 ] }
 log = "0.4"
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["full"], optional = true }
 tower = { version = "0.4", optional = true }
 tower-default-headers = { git = "https://github.com/banool/tower-default-headers-rs" }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.96"
 thiserror = "1.0.38"
 tracing = { version = "0.1.37", optional = true }
 http = "1"


### PR DESCRIPTION
The [first stable version of Leptos 0.7](https://github.com/leptos-rs/leptos/releases/tag/v0.7.0) was just released, so I figure I'd take the liberty of bumping the dependency.

I also updated the `wasm-bindgen` and `web-sys` crates to their most recent versions.