### PR TITLE
Update to `leptos@0.8.0-alpha`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ lazy_static = "1"
 leptos = "0.8.0-alpha"
 leptos_axum = { version = "0.8.0-alpha", default-features = false, optional = true }
 leptos_actix = { version = "0.8.0-alpha", default-features = false, optional = true }
-leptos-spin = { version = "0.2", default-features = false, optional = true }
 num = { version = "0.4", optional = true }
 paste = "1"
 send_wrapper = "0.6.0"
@@ -161,7 +160,6 @@ math = ["num"]
 on_click_outside = ["use_event_listener", "is"]
 signal_debounced = ["use_debounce_fn"]
 signal_throttled = ["use_throttle_fn"]
-spin = ["dep:leptos-spin", "dep:http1"]
 ssr = []
 storage = [
     "use_event_listener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ http1 = { version = "1", optional = true, package = "http" }
 http0_2 = { version = "0.2", optional = true, package = "http" }
 js-sys = "0.3"
 lazy_static = "1"
-leptos = "0.7"
-leptos_axum = { version = "0.7", default-features = false, optional = true }
-leptos_actix = { version = "0.7", default-features = false, optional = true }
+leptos = "0.8.0-alpha"
+leptos_axum = { version = "0.8.0-alpha", default-features = false, optional = true }
+leptos_actix = { version = "0.8.0-alpha", default-features = false, optional = true }
 leptos-spin = { version = "0.2", default-features = false, optional = true }
 num = { version = "0.4", optional = true }
 paste = "1"
@@ -48,8 +48,8 @@ codee = { version = "0.3", features = [
     "prost",
 ] }
 getrandom = { version = "0.2", features = ["js"] }
-leptos_meta = "0.7"
-rand = "0.8"
+leptos_meta = "0.8.0-alpha"
+rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 unic-langid = { version = "0.9", features = ["macros"] }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -78,15 +78,15 @@ members = [
 exclude = ["ssr", "use_webtransport_with_server"]
 
 [workspace.dependencies]
-leptos = "0.7"
-codee = "0.2"
+leptos = "0.8.0-alpha"
+codee = "0.3"
 console_error_panic_hook = "0.1"
 console_log = "1"
 log = "0.4"
 leptos-use = { path = "..", features = ["docs"] }
 web-sys = "0.3"
 wasm-bindgen = "0.2"
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = "0.3"
 
 [package]
 name = "leptos-use-examples"

--- a/examples/use_cookie/src/main.rs
+++ b/examples/use_cookie/src/main.rs
@@ -2,7 +2,7 @@ use codee::string::FromToStringCodec;
 use leptos::prelude::*;
 use leptos_use::docs::demo_or_body;
 use leptos_use::use_cookie;
-use rand::prelude::*;
+use rand::random;
 
 #[component]
 fn Demo() -> impl IntoView {

--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -127,7 +127,7 @@ use wasm_bindgen::JsCast;
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
+/// In case you're neither using Axum nor Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading the color scheme header value using the option
 /// [`crate::UseColorModeOptions::ssr_color_header_getter`].
 ///

--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -123,11 +123,11 @@ use wasm_bindgen::JsCast;
 /// as well as potential server requirements.
 ///
 /// > If you're using `axum` you have to enable the `"axum"` feature in your Cargo.toml.
-/// > In case it's `actix-web` enable the feature `"actix"`, for `spin` enable `"spin"`.
+/// > In case it's `actix-web` enable the feature `"actix"`.
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix nor Spin, or the default implementation is not to your liking,
+/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading the color scheme header value using the option
 /// [`crate::UseColorModeOptions::ssr_color_header_getter`].
 ///
@@ -497,7 +497,7 @@ where
     /// Getter function to return the string value of the
     /// [`Sec-CH-Prefers-Color-Scheme`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme)
     /// header.
-    /// When you use one of the features `"axum"`, `"actix"` or `"spin"` there's a valid default
+    /// When you use one of the features `"axum"` or `"actix"` there's a valid default
     /// implementation provided.
     #[allow(dead_code)]
     ssr_color_header_getter: Arc<dyn Fn() -> Option<String> + Send + Sync>,

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 /// # use leptos::prelude::*;
 /// # use leptos_use::use_cookie;
 /// # use codee::string::FromToStringCodec;
-/// # use rand::prelude::*;
+/// # use rand::random;
 ///
 /// #
 /// # #[component]

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -103,7 +103,7 @@ use std::sync::Arc;
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
+/// In case you're neither using Axum nor Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading and writing the cookie header value.
 ///
 /// ```

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -99,11 +99,11 @@ use std::sync::Arc;
 /// this will have no effect.
 ///
 /// > If you're using `axum` you have to enable the `"axum"` feature in your Cargo.toml.
-/// > In case it's `actix-web` enable the feature `"actix"`, for `spin` enable `"spin"`.
+/// > In case it's `actix-web` enable the feature `"actix"`..
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix nor Spin, or the default implementation is not to your liking,
+/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading and writing the cookie header value.
 ///
 /// ```
@@ -484,11 +484,11 @@ pub struct UseCookieOptions<T, E, D> {
     readonly: bool,
 
     /// Getter function to return the string value of the cookie header.
-    /// When you use one of the features `"axum"`, `"actix"` or `"spin"` there's a valid default implementation provided.
+    /// When you use one of the features `"axum"` or `"actix"` there's a valid default implementation provided.
     ssr_cookies_header_getter: Arc<dyn Fn() -> Option<String> + Send + Sync>,
 
     /// Function to add a set cookie header to the response on the server.
-    /// When you use one of the features `"axum"`, `"actix"` or `"spin"` there's a valid default implementation provided.
+    /// When you use one of the features `"axum"` or `"actix"` there's a valid default implementation provided.
     ssr_set_cookie: Arc<dyn Fn(&Cookie) + Send + Sync>,
 
     /// Callback for encoding/decoding errors. Defaults to logging the error to the console.
@@ -518,28 +518,22 @@ impl<T, E, D> Default for UseCookieOptions<T, E, D> {
                     use leptos_actix::ResponseOptions;
                     #[cfg(feature = "axum")]
                     use leptos_axum::ResponseOptions;
-                    #[cfg(feature = "spin")]
-                    use leptos_spin::ResponseOptions;
 
                     #[cfg(feature = "actix")]
                     const SET_COOKIE: http0_2::HeaderName = http0_2::header::SET_COOKIE;
-                    #[cfg(any(feature = "axum", feature = "spin"))]
+                    #[cfg(feature = "axum")]
                     const SET_COOKIE: http1::HeaderName = http1::header::SET_COOKIE;
 
                     #[cfg(feature = "actix")]
                     type HeaderValue = http0_2::HeaderValue;
-                    #[cfg(any(feature = "axum", feature = "spin"))]
+                    #[cfg(feature = "axum")]
                     type HeaderValue = http1::HeaderValue;
 
-                    #[cfg(all(
-                        not(feature = "axum"),
-                        not(feature = "actix"),
-                        not(feature = "spin")
-                    ))]
+                    #[cfg(all(not(feature = "axum"), not(feature = "actix")))]
                     {
                         use leptos::logging::warn;
                         let _ = cookie;
-                        warn!("If you're using use_cookie without the feature `axum`, `actix` or `spin` enabled, you should provide the option `ssr_set_cookie`");
+                        warn!("If you're using use_cookie without the feature `axum` or `actix` enabled, you should provide the option `ssr_set_cookie`");
                     }
 
                     #[cfg(any(feature = "axum", feature = "actix"))]
@@ -550,13 +544,6 @@ impl<T, E, D> Default for UseCookieOptions<T, E, D> {
                             {
                                 response_options.append_header(SET_COOKIE, header_value);
                             }
-                        }
-                    }
-                    #[cfg(feature = "spin")]
-                    {
-                        if let Some(response_options) = use_context::<ResponseOptions>() {
-                            let header_value = cookie.encoded().to_string().as_bytes().to_vec();
-                            response_options.append_header(SET_COOKIE.as_str(), &header_value);
                         }
                     }
                 }

--- a/src/use_locales.rs
+++ b/src/use_locales.rs
@@ -34,11 +34,11 @@ use std::sync::Arc;
 /// On the server this returns the parsed value of the `accept-language` header.
 ///
 /// > If you're using `axum` you have to enable the `"axum"` feature in your Cargo.toml.
-/// > In case it's `actix-web` enable the feature `"actix"`, for `spin` enable `"spin"`.
+/// > In case it's `actix-web` enable the feature `"actix"`.
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix nor Spin, or the default implementation is not to your liking,
+/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading the language header value using the option
 /// [`crate::UseLocalesOptions::ssr_lang_header_getter`].
 pub fn use_locales() -> Signal<Vec<String>> {
@@ -99,7 +99,7 @@ pub fn use_locales_with_options(options: UseLocalesOptions) -> Signal<Vec<String
 #[derive(DefaultBuilder)]
 pub struct UseLocalesOptions {
     /// Getter function to return the string value of the accept languange header.
-    /// When you use one of the features `"axum"`, `"actix"` or `"spin"` there's a valid default implementation provided.
+    /// When you use one of the features `"axum"` or `"actix"` there's a valid default implementation provided.
     #[allow(dead_code)]
     ssr_lang_header_getter: Arc<dyn Fn() -> Option<String>>,
 }

--- a/src/use_locales.rs
+++ b/src/use_locales.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
+/// In case you're neither using Axum nor Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading the language header value using the option
 /// [`crate::UseLocalesOptions::ssr_lang_header_getter`].
 pub fn use_locales() -> Signal<Vec<String>> {

--- a/src/use_preferred_dark.rs
+++ b/src/use_preferred_dark.rs
@@ -29,11 +29,11 @@ use std::sync::Arc;
 /// as well as potential server requirements.
 ///
 /// > If you're using `axum` you have to enable the `"axum"` feature in your Cargo.toml.
-/// > In case it's `actix-web` enable the feature `"actix"`, for `spin` enable `"spin"`.
+/// > In case it's `actix-web` enable the feature `"actix"`.
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix nor Spin, or the default implementation is not to your liking,
+/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading the color scheme header value using the option
 /// [`crate::UsePreferredDarkOptions::ssr_color_header_getter`].
 ///
@@ -67,7 +67,7 @@ pub struct UsePreferredDarkOptions {
     /// Getter function to return the string value of the
     /// [`Sec-CH-Prefers-Color-Scheme`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme)
     /// header.
-    /// When you use one of the features `"axum"`, `"actix"` or `"spin"` there's a valid default
+    /// When you use one of the features `"axum"` or `"actix"` there's a valid default
     /// implementation provided.
     #[allow(dead_code)]
     pub(crate) ssr_color_header_getter: Arc<dyn Fn() -> Option<String> + Send + Sync>,

--- a/src/use_preferred_dark.rs
+++ b/src/use_preferred_dark.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix or the default implementation is not to your liking,
+/// In case you're neither using Axum nor Actix or the default implementation is not to your liking,
 /// you can provide your own way of reading the color scheme header value using the option
 /// [`crate::UsePreferredDarkOptions::ssr_color_header_getter`].
 ///

--- a/src/use_prefers_reduced_motion.rs
+++ b/src/use_prefers_reduced_motion.rs
@@ -44,11 +44,11 @@ use std::sync::Arc;
 /// as well as potential serve requirements.
 ///
 /// > If you're using `axum` you have to enable the `"axum"` feature in your Cargo.toml.
-/// > In case it's `actix-web` enable the feature `"actix"`, for `spin` enable `"spin"`.
+/// > In case it's `actix-web` enable the feature `"actix"`.
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix nor Spin, or the default implementation is not to your
+/// In case you're neither using Axum, Actix or the default implementation is not to your
 /// liking, you can provide your own way of reading the reduced motion header value using the option
 /// [`crate::UsePrefersReducedMotionOptions::ssr_motion_header_getter`].
 ///
@@ -82,7 +82,7 @@ pub struct UsePrefersReducedMotionOptions {
     /// Getter function to return the string value of the
     /// [`Sec-CH-Prefers-Reduced-Motion`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Reduced-Motion)
     /// header.
-    /// When you use one of the features `"axum"`, `"actix"` or `"spin"` there's a valid default
+    /// When you use one of the features `"axum"` or `"actix"` there's a valid default
     /// implementation provided.
     #[allow(dead_code)]
     pub(crate) ssr_motion_header_getter: Arc<dyn Fn() -> Option<String> + Send + Sync>,

--- a/src/use_prefers_reduced_motion.rs
+++ b/src/use_prefers_reduced_motion.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 ///
 /// ### Bring your own header
 ///
-/// In case you're neither using Axum, Actix or the default implementation is not to your
+/// In case you're neither using Axum nor Actix or the default implementation is not to your
 /// liking, you can provide your own way of reading the reduced motion header value using the option
 /// [`crate::UsePrefersReducedMotionOptions::ssr_motion_header_getter`].
 ///

--- a/src/utils/header.rs
+++ b/src/utils/header.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "actix")]
 use http0_2::HeaderName;
-#[cfg(any(feature = "axum", feature = "spin"))]
+#[cfg(feature = "axum")]
 use http1::HeaderName;
 use leptos::prelude::*;
 
@@ -8,7 +8,7 @@ use leptos::prelude::*;
 ///
 /// This function is only meant to be used on the server.
 /// So it is only defined when the feature `"ssr"` is enabled together with one of the
-/// features `"axum"`, `"actix"` or `"spin"`.
+/// features `"axum"` or `"actix"`.
 ///
 /// ## Example
 ///
@@ -26,18 +26,12 @@ where
     #[cfg(all(feature = "actix", feature = "axum"))]
     compile_error!("You can only enable one of features \"actix\" and \"axum\" at the same time");
 
-    #[cfg(all(feature = "actix", feature = "spin"))]
-    compile_error!("You can only enable one of features \"actix\" and \"spin\" at the same time");
-
-    #[cfg(all(feature = "axum", feature = "spin"))]
-    compile_error!("You can only enable one of features \"axum\" and \"spin\" at the same time");
-
     #[cfg(feature = "actix")]
     type HeaderValue = http0_2::HeaderValue;
     #[cfg(feature = "axum")]
     type HeaderValue = http1::HeaderValue;
 
-    #[cfg(any(feature = "axum", feature = "actix", feature = "spin"))]
+    #[cfg(any(feature = "axum", feature = "actix"))]
     let headers;
     #[cfg(feature = "actix")]
     {
@@ -47,10 +41,6 @@ where
     #[cfg(feature = "axum")]
     {
         headers = use_context::<http1::request::Parts>().map(|parts| parts.headers);
-    }
-    #[cfg(feature = "spin")]
-    {
-        headers = use_context::<leptos_spin::RequestParts>().map(|parts| parts.headers().clone());
     }
 
     #[cfg(any(feature = "axum", feature = "actix"))]
@@ -63,15 +53,6 @@ where
                 .to_str()
                 .unwrap_or_default()
                 .to_owned()
-        })
-    }
-    #[cfg(feature = "spin")]
-    {
-        headers.and_then(|headers| {
-            headers
-                .iter()
-                .find(|(key, _)| **key == name)
-                .and_then(|(_, value)| String::from_utf8(value.to_vec()).ok())
         })
     }
 }

--- a/src/utils/header_macro.rs
+++ b/src/utils/header_macro.rs
@@ -10,12 +10,11 @@ macro_rules! get_header {
         if cfg!(feature = "ssr") {
             #[cfg(all(
                 not(feature = "axum"),
-                not(feature = "actix"),
-                not(feature = "spin")
+                not(feature = "actix")
             ))]
             {
                 leptos::logging::warn!(
-                    "If you're using `{}` with SSR but without any of the features `axum`, `actix` or `spin` enabled, you have to provide the option `{}`",
+                    "If you're using `{}` with SSR but without any of the features `axum`, `actix` enabled, you have to provide the option `{}`",
                     stringify!($function_name),
                     stringify!($option_name)
                 );
@@ -25,11 +24,11 @@ macro_rules! get_header {
             #[cfg(feature = "actix")]
             #[allow(unused_imports)]
             use http0_2::{HeaderName, header::*};
-            #[cfg(any(feature = "axum", feature = "spin"))]
+            #[cfg(feature = "axum")]
             #[allow(unused_imports)]
             use http1::{HeaderName, header::*};
 
-            #[cfg(any(feature = "axum", feature = "actix", feature = "spin"))]
+            #[cfg(any(feature = "axum", feature = "actix"))]
             {
                 let header_name = $header_name;
                 crate::utils::header(header_name)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,5 @@
 mod filters;
-#[cfg(all(
-    feature = "ssr",
-    any(feature = "axum", feature = "actix", feature = "spin")
-))]
+#[cfg(all(feature = "ssr", any(feature = "axum", feature = "actix")))]
 mod header;
 mod header_macro;
 #[cfg(feature = "is")]
@@ -15,10 +12,7 @@ mod signal_filtered;
 mod use_derive_signal;
 
 pub use filters::*;
-#[cfg(all(
-    feature = "ssr",
-    any(feature = "axum", feature = "actix", feature = "spin")
-))]
+#[cfg(all(feature = "ssr", any(feature = "axum", feature = "actix")))]
 pub use header::*;
 #[allow(unused_imports)]
 pub(crate) use header_macro::*;


### PR DESCRIPTION
# Description

- Remove references to the `leptos-spin` dependency which hasn't received updates in a while and is still stuck on `leptos@0.6`.
- Update to `rand@0.9`.

This pull request is to keep track track of the `leptos@0.8` updates. 

I'm happy to make changes requested.
