### PR TITLE
fix: relax `chrono` pinned version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://leptos-use.rs"
 [dependencies]
 actix-web = { version = "4", optional = true, default-features = false }
 cfg-if = "1"
-chrono = "=0.4.40"
+chrono = "0.4.41"
 codee = { version = "0.3", optional = true }
 cookie = { version = "0.18", features = ["percent-encode"], optional = true }
 default-struct-builder = "0.5"


### PR DESCRIPTION
Pinning a dependency in a library may not be a good practice as it causes version mismatches and duplication, ultimately resulting in larger binary sizes in end apps. Besides that, pinning `chrono` to version `=0.4.40` would not be beneficial as it already follows semver versioning and is pinned to patch versions.

Supersedes: #254 