### PR TITLE
fix: gate `chrono` by `use_calendar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://leptos-use.rs"
 [dependencies]
 actix-web = { version = "4", optional = true, default-features = false }
 cfg-if = "1"
-chrono = "=0.4.40"
+chrono = { version = "=0.4.40", optional = true }
 codee = { version = "0.3", optional = true }
 cookie = { version = "0.18", features = ["percent-encode"], optional = true }
 default-struct-builder = "0.5"
@@ -129,7 +129,9 @@ default = [
     "watch_with_options",
     "whenever",
 ]
-use_calendar = []
+use_calendar = [
+    "dep:chrono"
+]
 use_textarea_autosize = [
     "use_resize_observer",
     "web-sys/CssStyleDeclaration",


### PR DESCRIPTION
I noticed that `chrono` is included unconditionally in `leptos-use`'s dependencies. Since chrono is only used by the `use_calendar` feature (as far as I can tell), it would be more efficient to make it an optional dependency and gate it behind the `use_calendar` feature in `Cargo.toml`.

Related:
#232 #255 #254 