### PR TITLE
use_color_mode put frontend only logic behind feature gate

### DIFF
--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -1,5 +1,5 @@
 use crate::core::url;
-use crate::core::{ElementMaybeSignal, IntoElementMaybeSignal, MaybeRwSignal};
+use crate::core::{IntoElementMaybeSignal, MaybeRwSignal};
 use crate::storage::{use_storage_with_options, StorageType, UseStorageOptions};
 use crate::utils::get_header;
 use crate::{
@@ -14,6 +14,10 @@ use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
+
+#[cfg(not(feature = "ssr"))]
+use crate::core::ElementMaybeSignal;
+#[cfg(not(feature = "ssr"))]
 use wasm_bindgen::JsCast;
 
 /// Reactive color mode (dark / light / customs) with auto data persistence.
@@ -246,73 +250,78 @@ where
         }
     });
 
-    let target = target.into_element_maybe_signal();
+    #[cfg(not(feature = "ssr"))]
+    {
+        let target = target.into_element_maybe_signal();
 
-    let update_html_attrs = {
-        move |target: ElementMaybeSignal<web_sys::Element>, attribute: String, value: ColorMode| {
-            let el = target.get_untracked();
+        let update_html_attrs = {
+            move |target: ElementMaybeSignal<web_sys::Element>,
+                  attribute: String,
+                  value: ColorMode| {
+                let el = target.get_untracked();
 
-            if let Some(el) = el {
-                let mut style: Option<web_sys::HtmlStyleElement> = None;
-                if !transition_enabled {
-                    if let Ok(styl) = document().create_element("style") {
-                        if let Some(head) = document().head() {
-                            let styl: web_sys::HtmlStyleElement = styl.unchecked_into();
-                            let style_string = "*,*::before,*::after{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}";
-                            styl.set_text_content(Some(style_string));
-                            let _ = head.append_child(&styl);
-                            style = Some(styl);
-                        }
-                    }
-                }
-
-                if attribute == "class" {
-                    for mode in &modes {
-                        if &value.to_string() == mode {
-                            let _ = el.class_list().add_1(mode);
-                        } else {
-                            let _ = el.class_list().remove_1(mode);
-                        }
-                    }
-                } else {
-                    let _ = el.set_attribute(&attribute, &value.to_string());
-                }
-
-                if !transition_enabled {
-                    if let Some(style) = style {
-                        if let Some(head) = document().head() {
-                            // Calling getComputedStyle forces the browser to redraw
-                            if let Ok(Some(style)) = window().get_computed_style(&style) {
-                                let _ = style.get_property_value("opacity");
+                if let Some(el) = el {
+                    let mut style: Option<web_sys::HtmlStyleElement> = None;
+                    if !transition_enabled {
+                        if let Ok(styl) = document().create_element("style") {
+                            if let Some(head) = document().head() {
+                                let styl: web_sys::HtmlStyleElement = styl.unchecked_into();
+                                let style_string = "*,*::before,*::after{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}";
+                                styl.set_text_content(Some(style_string));
+                                let _ = head.append_child(&styl);
+                                style = Some(styl);
                             }
+                        }
+                    }
 
-                            let _ = head.remove_child(&style);
+                    if attribute == "class" {
+                        for mode in &modes {
+                            if &value.to_string() == mode {
+                                let _ = el.class_list().add_1(mode);
+                            } else {
+                                let _ = el.class_list().remove_1(mode);
+                            }
+                        }
+                    } else {
+                        let _ = el.set_attribute(&attribute, &value.to_string());
+                    }
+
+                    if !transition_enabled {
+                        if let Some(style) = style {
+                            if let Some(head) = document().head() {
+                                // Calling getComputedStyle forces the browser to redraw
+                                if let Ok(Some(style)) = window().get_computed_style(&style) {
+                                    let _ = style.get_property_value("opacity");
+                                }
+
+                                let _ = head.remove_child(&style);
+                            }
                         }
                     }
                 }
             }
-        }
-    };
+        };
 
-    let default_on_changed = move |mode: ColorMode| {
-        update_html_attrs(target, attribute.clone(), mode);
-    };
+        let default_on_changed = move |mode: ColorMode| {
+            update_html_attrs(target, attribute.clone(), mode);
+        };
 
-    let on_changed = move |mode: ColorMode| {
-        on_changed(mode, Arc::new(default_on_changed.clone()));
-    };
+        let on_changed = move |mode: ColorMode| {
+            on_changed(mode, Arc::new(default_on_changed.clone()));
+        };
 
-    Effect::new({
-        let on_changed = on_changed.clone();
+        Effect::new({
+            let on_changed = on_changed.clone();
 
-        move |_| {
-            on_changed.clone()(state.get());
-        }
-    });
+            move |_| {
+                on_changed.clone()(state.get());
+            }
+        });
 
-    on_cleanup(move || {
-        on_changed(state.get());
-    });
+        on_cleanup(move || {
+            on_changed(state.get());
+        });
+    }
 
     let mode = Signal::derive(move || if emit_auto { store.get() } else { state.get() });
 

--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -6,6 +6,7 @@ use crate::{
     sync_signal_with_options, use_cookie_with_options, use_preferred_dark_with_options,
     SyncSignalOptions, UseCookieOptions, UsePreferredDarkOptions,
 };
+use cfg_if::cfg_if;
 use codee::string::FromToStringCodec;
 use default_struct_builder::DefaultBuilder;
 use leptos::prelude::*;
@@ -15,10 +16,10 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
 
-#[cfg(not(feature = "ssr"))]
-use crate::core::ElementMaybeSignal;
-#[cfg(not(feature = "ssr"))]
-use wasm_bindgen::JsCast;
+cfg_if! { if #[cfg(not(feature = "ssr"))] {
+    use crate::core::ElementMaybeSignal;
+    use wasm_bindgen::JsCast;
+}}
 
 /// Reactive color mode (dark / light / customs) with auto data persistence.
 ///
@@ -156,6 +157,7 @@ where
     El: IntoElementMaybeSignal<web_sys::Element, M>,
     M: ?Sized,
 {
+    #[allow(unused_variables)]
     let UseColorModeOptions {
         target,
         attribute,
@@ -176,14 +178,6 @@ where
         ssr_color_header_getter,
         _marker,
     } = options;
-
-    let modes: Vec<String> = custom_modes
-        .into_iter()
-        .chain(vec![
-            ColorMode::Dark.to_string(),
-            ColorMode::Light.to_string(),
-        ])
-        .collect();
 
     let preferred_dark = use_preferred_dark_with_options(UsePreferredDarkOptions {
         ssr_color_header_getter,
@@ -252,6 +246,14 @@ where
 
     #[cfg(not(feature = "ssr"))]
     {
+        let modes: Vec<String> = custom_modes
+            .into_iter()
+            .chain(vec![
+                ColorMode::Dark.to_string(),
+                ColorMode::Light.to_string(),
+            ])
+            .collect();
+
         let target = target.into_element_maybe_signal();
 
         let update_html_attrs = {


### PR DESCRIPTION
I keep getting panics from `use_color_mode` in a Axum/SSR app.

Partial stack trace:

```
thread 'tokio-runtime-worker' panicked at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reactive_graph-0.1.8/src/owner/storage.rs:141:34:
Dereferenced SendWrapper<T> variable from a thread different to the one it has been created with.
stack backtrace:
...
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reactive_graph-0.1.8/src/traits.rs:728:9
  22: <leptos_use::core::element_maybe_signal::ElementMaybeSignal<T> as reactive_graph::traits::WithUntracked>::try_with_untracked
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos-use-0.15.8/src/core/element_maybe_signal.rs:126:50
  23: <T as reactive_graph::traits::GetUntracked>::try_get_untracked
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reactive_graph-0.1.8/src/traits.rs:367:9
  24: reactive_graph::traits::GetUntracked::get_untracked
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reactive_graph-0.1.8/src/traits.rs:354:9
  25: leptos_use::use_color_mode::use_color_mode_with_options::{{closure}}
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos-use-0.15.8/src/use_color_mode.rs:253:22
  26: leptos_use::use_color_mode::use_color_mode_with_options::{{closure}}
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos-use-0.15.8/src/use_color_mode.rs:298:9
  27: <leptos_use::use_color_mode::UseColorModeOptions<&str,str> as core::default::Default>::default::{{closure}}
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos-use-0.15.8/src/use_color_mode.rs:520:63
  28: leptos_use::use_color_mode::use_color_mode_with_options::{{closure}}
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos-use-0.15.8/src/use_color_mode.rs:302:9
  29: leptos_use::use_color_mode::use_color_mode_with_options::{{closure}}
             at /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos-use-0.15.8/src/use_color_mode.rs:314:9
  30: core::ops::function::FnOnce::call_once{{vtable.shim}}
...
```

The stack trace starts from `on_cleanup` and the problematic call is to `target.get_untracked()`.  Given nothing in this logic needs to run on the backend since it's all trying to target an Element, I figured it would make sense to avoid calling this logic altogether rather than trying to deep dive into SendWrapper concurrency issues.