### PR TITLE
feat: :sparkles: Added change_url to use_event_source.

### DIFF
--- a/src/use_event_source.rs
+++ b/src/use_event_source.rs
@@ -356,6 +356,7 @@ where
         let _ = set_ready_state;
         let _ = set_event_source;
         let _ = set_error;
+        let _ = url;
     }
 
     UseEventSourceReturn {


### PR DESCRIPTION
With change_url you can change reactivly the url of the SSE server. This is usefull, if you encode dynamic data in the url of the server, e.g. an uuid of some object you want to receive updates from.

No breaking changes.