### PR TITLE
Grab multiple elements from `str` selector

### DIFF
--- a/src/core/elements_maybe_signal.rs
+++ b/src/core/elements_maybe_signal.rs
@@ -283,7 +283,7 @@ where
             }
         }
     }
-    els.into_iter().map(|v| T::try_from(v).ok()).collect()
+    els.into_iter().map(|v| Some(T::from(v))).collect()
 }
 
 pub fn els_signal_by_sel<T>(sel: &str) -> Signal<Vec<Option<T>>, LocalStorage>


### PR DESCRIPTION
Fixes #280 

Enables `str` markers to select multiple elements. 

Ran the following and all tests passed
```
cargo test --features math,docs,ssr --doc use_intersection_observer
cargo test --features math,docs,ssr
```