### PR TITLE
Fix broken link in use_locale doc

### DIFF
--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -10,7 +10,7 @@ use unic_langid::LanguageIdentifier;
 ///
 /// > If `supported` is empty, this function will panic!
 ///
-/// Matching is done by using the [`fn@unic_langid::LanguageIdentifier::matches`] method.
+/// Matching is done by using the [`unic_langid::LanguageIdentifier::matches`](https://docs.rs/unic-langid/latest/unic_langid/struct.LanguageIdentifier.html#method.matches) method.
 ///
 /// ## Demo
 ///


### PR DESCRIPTION
The current syntax only works for same-crate references.
The link on https://leptos-use.rs/intl/use_locale.html leads to a non-existent doc page: https://docs.rs/leptos-use/latest/leptos_use/fn.unic_langid::LanguageIdentifier::matches.html