### PR TITLE
Minor edits on `js` macro

### DIFF
--- a/src/use_intl_number_format.rs
+++ b/src/use_intl_number_format.rs
@@ -714,48 +714,48 @@ impl From<UseIntlNumberFormatOptions> for js_sys::Object {
     fn from(options: UseIntlNumberFormatOptions) -> Self {
         let obj = Self::new();
 
-        js!(obj["compactDisplay"] = options.compact_display);
+        _ = js!(obj["compactDisplay"] = options.compact_display);
 
         if let Some(currency) = options.currency {
-            js!(obj["currency"] = currency);
+            _ = js!(obj["currency"] = currency);
         }
 
-        js!(obj["currencyDisplay"] = options.currency_display);
-        js!(obj["currencySign"] = options.currency_sign);
-        js!(obj["localeMatcher"] = options.locale_matcher);
-        js!(obj["notation"] = options.notation);
+        _ = js!(obj["currencyDisplay"] = options.currency_display);
+        _ = js!(obj["currencySign"] = options.currency_sign);
+        _ = js!(obj["localeMatcher"] = options.locale_matcher);
+        _ = js!(obj["notation"] = options.notation);
 
         if let Some(numbering_system) = options.numbering_system {
-            js!(obj["numberingSystem"] = numbering_system);
+            _ = js!(obj["numberingSystem"] = numbering_system);
         }
 
-        js!(obj["signDisplay"] = options.sign_display);
-        js!(obj["style"] = options.style);
+        _ = js!(obj["signDisplay"] = options.sign_display);
+        _ = js!(obj["style"] = options.style);
 
         if let Some(unit) = options.unit {
-            js!(obj["unit"] = unit);
+            _ = js!(obj["unit"] = unit);
         }
 
-        js!(obj["unitDisplay"] = options.unit_display);
-        js!(obj["useGrouping"] = options.use_grouping);
-        js!(obj["roundingMode"] = options.rounding_mode);
-        js!(obj["roundingPriority"] = options.rounding_priority);
-        js!(obj["roundingIncrement"] = options.rounding_increment);
-        js!(obj["trailingZeroDisplay"] = options.trailing_zero_display);
-        js!(obj["minimumIntegerDigits"] = options.minimum_integer_digits);
+        _ = js!(obj["unitDisplay"] = options.unit_display);
+        _ = js!(obj["useGrouping"] = options.use_grouping);
+        _ = js!(obj["roundingMode"] = options.rounding_mode);
+        _ = js!(obj["roundingPriority"] = options.rounding_priority);
+        _ = js!(obj["roundingIncrement"] = options.rounding_increment);
+        _ = js!(obj["trailingZeroDisplay"] = options.trailing_zero_display);
+        _ = js!(obj["minimumIntegerDigits"] = options.minimum_integer_digits);
 
         if let Some(minimum_fraction_digits) = options.minimum_fraction_digits {
-            js!(obj["minimumFractionDigits"] = minimum_fraction_digits);
+            _ = js!(obj["minimumFractionDigits"] = minimum_fraction_digits);
         }
         if let Some(maximum_fraction_digits) = options.maximum_fraction_digits {
-            js!(obj["maximumFractionDigits"] = maximum_fraction_digits);
+            _ = js!(obj["maximumFractionDigits"] = maximum_fraction_digits);
         }
 
         if let Some(minimum_significant_digits) = options.minimum_significant_digits {
-            js!(obj["minimumSignificantDigits"] = minimum_significant_digits);
+            _ = js!(obj["minimumSignificantDigits"] = minimum_significant_digits);
         }
         if let Some(maximum_significant_digits) = options.maximum_significant_digits {
-            js!(obj["maximumSignificantDigits"] = maximum_significant_digits);
+            _ = js!(obj["maximumSignificantDigits"] = maximum_significant_digits);
         }
 
         obj

--- a/src/use_permission.rs
+++ b/src/use_permission.rs
@@ -122,7 +122,7 @@ async fn query_permission(
     use wasm_bindgen::JsCast;
 
     let permission_object = js_sys::Object::new();
-    js!(permission_object["name"] = permission);
+    _ = js!(permission_object["name"] = permission);
 
     let permission_state: web_sys::PermissionStatus = js_fut!(
         window()

--- a/src/use_user_media.rs
+++ b/src/use_user_media.rs
@@ -233,7 +233,7 @@ async fn create_media(
 
                 if let Some(value) = zoom {
                     // TODO : once web_sys implements this add it to the methods above
-                    js! { js_value["zoom"] = value.to_jsvalue()};
+                    _ = js!(js_value["zoom"] = value.to_jsvalue());
                 }
 
                 constraints.set_video(&js_value);

--- a/src/utils/js.rs
+++ b/src/utils/js.rs
@@ -3,22 +3,26 @@
 /// Expand to common JavaScript operations that are too long in Rust.
 ///
 /// Holds three primary rules:
-/// - `attribute in object`: Check if the attribute is in the object (see [`JsValue::js_in`]).
+/// - `[attribute] in object`: Check if the attribute is in the object (see [`JsValue::js_in`]).
+///   Alternatively, `attribute in object` if `attribute` is a literal.
 /// - `object[attribute]`: Get the value of the object attribute (see [`Reflect::get`]).
 /// - `object[attribute] = val`: Assign to the attribute of the object (see [`Reflect::set`]).
 ///
 /// [`JsValue`]: wasm_bindgen::JsValue
 #[macro_export]
 macro_rules! js {
+    ([$attr:expr] in $($obj:tt)*) => {
+        wasm_bindgen::JsValue::from($attr).js_in($($obj)*)
+    };
     ($attr:literal in $($obj:tt)*) => {
         wasm_bindgen::JsValue::from($attr).js_in($($obj)*)
     };
-    ($obj:ident[$attr:literal] = $($val:tt)*) => {
+    ($obj:ident[$attr:expr] = $($val:tt)*) => {
         {
             let _ = js_sys::Reflect::set(&$obj, &$attr.into(), &($($val)*).into());
         }
     };
-    ($obj:ident[$attr:literal]) => {
+    ($obj:ident[$attr:expr]) => {
         js_sys::Reflect::get(&$obj, &$attr.into())
     };
 }

--- a/src/utils/js.rs
+++ b/src/utils/js.rs
@@ -18,9 +18,7 @@ macro_rules! js {
         wasm_bindgen::JsValue::from($attr).js_in($($obj)*)
     };
     ($obj:ident[$attr:expr] = $($val:tt)*) => {
-        {
-            let _ = js_sys::Reflect::set(&$obj, &$attr.into(), &($($val)*).into());
-        }
+        js_sys::Reflect::set(&$obj, &$attr.into(), &($($val)*).into())
     };
     ($obj:ident[$attr:expr]) => {
         js_sys::Reflect::get(&$obj, &$attr.into())

--- a/src/utils/js.rs
+++ b/src/utils/js.rs
@@ -1,3 +1,13 @@
+//! Holds JavaScript utilities and especially the [`js`] macro.
+
+/// Expand to common JavaScript operations that are too long in Rust.
+///
+/// Holds three primary rules:
+/// - `attribute in object`: Check if the attribute is in the object (see [`JsValue::js_in`]).
+/// - `object[attribute]`: Get the value of the object attribute (see [`Reflect::get`]).
+/// - `object[attribute] = val`: Assign to the attribute of the object (see [`Reflect::set`]).
+///
+/// [`JsValue`]: wasm_bindgen::JsValue
 #[macro_export]
 macro_rules! js {
     ($attr:literal in $($obj:tt)*) => {
@@ -13,6 +23,7 @@ macro_rules! js {
     };
 }
 
+/// Create a [`wasm_bindgen_futures::JsFuture`] from the given tokens.
 #[macro_export]
 macro_rules! js_fut {
     ($($obj:tt)*) => {

--- a/src/utils/js.rs
+++ b/src/utils/js.rs
@@ -4,7 +4,9 @@ macro_rules! js {
         wasm_bindgen::JsValue::from($attr).js_in($($obj)*)
     };
     ($obj:ident[$attr:literal] = $($val:tt)*) => {
-        let _ = js_sys::Reflect::set(&$obj, &$attr.into(), &($($val)*).into());
+        {
+            let _ = js_sys::Reflect::set(&$obj, &$attr.into(), &($($val)*).into());
+        }
     };
     ($obj:ident[$attr:literal]) => {
         js_sys::Reflect::get(&$obj, &$attr.into())
@@ -16,5 +18,4 @@ macro_rules! js_fut {
     ($($obj:tt)*) => {
         wasm_bindgen_futures::JsFuture::from($($obj)*)
     };
-
 }


### PR DESCRIPTION
Once in a lifetime, situation does not allow for `let` keyword in certain contexts (example below, not the best but still proves the point). There is no apparent downside to this extra wrap in `{}`. Alternatively, `let` can be safely remove instead of this.

This seemed so minor of a change that I did not bother with testing, reading any docs. I just saw no comments around the macro so I assumed it's safe to modify and write about. Sorry!

```rust
error: expected expression, found `let` statement
   --> src/x.rs:185:23
    |
185 |     this1.and_then(|i| js!(o["this1"] = i));
    |                        ^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
    = note: this error originates in the macro `js` (in Nightly builds, run with -Z macro-backtrace for more info)
```