### PR TITLE
Remove custom online fonts from the book

### DIFF
--- a/docs/book/src/custom.css
+++ b/docs/book/src/custom.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@400;600;700&display=swap');
 
 :root {
     --brand-color: #EF3939;

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -3,7 +3,6 @@
 <svg width="100%" height="100%" viewBox="0 0 98 115" version="1.1" xmlns="http://www.w3.org/2000/svg"
      style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
     <style type="text/css">
-        @import url('https://fonts.googleapis.com/css2?family=Quicksand&amp;display=swap');
 
         path.black, text {
             fill: #1e1838;


### PR DESCRIPTION
This is a niche issue. In any case, there are situations in which users cannot access `googleapis` and this makes running the books locally (with minimal instructions) hard (most browsers just halt the display until the font fetching has ended with success or not).

This is an issue for beginners, the main users of the book. Interestingly, it's only logical that one who compiles the book offline is even more likely to be a user with an unstable access to internet (or any network for that matter).

It's the results of a simple `grep` and may not make everything 100% offline but it's a good starting point:
`grep googleapis -R . -l | xargs -I {} sed -i '/google/d' {}`