### PR TITLE
Update use_favicon feature dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,10 @@ use_event_source = [
   "web-sys/EventSourceInit",
   "dep:codee",
 ]
-use_favicon = []
+use_favicon = [
+  "dep:web-sys",
+  "web-sys/HtmlLinkElement",
+]
 use_geolocation = [
   "use_window",
   "web-sys/Coordinates",


### PR DESCRIPTION
The use_favicon feature should work on its own
`leptos-use = { version = "0.18.3", default-features = false, features = ["use_favicon"]}`