### PR TITLE
fix: three critical bugs (panic, resource leak, corrupted callback state)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ serde = { version = "1", features = ["derive"] }
 unic-langid = { version = "0.9", features = ["macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+any_spawner = { version = "0.3", features = ["wasm-bindgen"] }
+# `csr` pulls in `reactive_graph/effects`, without which `Effect`s are compiled
+# out and effect-driven hooks cannot be tested in the browser.
+leptos = { version = "0.8", features = ["csr"] }
 wasm-bindgen-test = "0.3"
 
 [features]

--- a/src/use_cycle_list.rs
+++ b/src/use_cycle_list.rs
@@ -96,6 +96,10 @@ where
     let set = move |i: usize| {
         let length = list.read().len();
 
+        if length == 0 {
+            return state.get_untracked();
+        }
+
         let index = i % length;
         let value = list.read()[index].clone();
 
@@ -110,6 +114,10 @@ where
 
     let shift = move |delta: i64| {
         let length = list.read().len() as i64;
+
+        if length == 0 {
+            return state.get_untracked();
+        }
 
         let i = index.get_untracked() as i64 + delta;
         let index = (i % length) + length;

--- a/src/use_display_media.rs
+++ b/src/use_display_media.rs
@@ -96,6 +96,11 @@ pub fn use_display_media_with_options(
         stream.set(None);
     };
 
+    // Without this the tracks keep running (and the screen sharing indicator
+    // stays on) after the owner is disposed, with no handle left to stop them.
+    #[cfg(not(feature = "ssr"))]
+    on_cleanup(_stop);
+
     let start = sendwrap_fn!(move || {
         cfg_if! { if #[cfg(not(feature = "ssr"))] {
             leptos::task::spawn_local(async move {

--- a/src/use_user_media.rs
+++ b/src/use_user_media.rs
@@ -101,6 +101,11 @@ pub fn use_user_media_with_options(
         stream.set(None);
     };
 
+    // Without this the tracks keep running (and the camera/microphone indicator
+    // stays on) after the owner is disposed, with no handle left to stop them.
+    #[cfg(not(feature = "ssr"))]
+    on_cleanup(_stop);
+
     let start = {
         #[cfg(not(feature = "ssr"))]
         let _start = _start.clone();

--- a/src/watch_with_options.rs
+++ b/src/watch_with_options.rs
@@ -141,7 +141,13 @@ where
                 filtered_callback().lock().unwrap().take()
             };
 
-            prev_callback_value.replace(callback_value);
+            // Only overwrite when the callback actually ran. A debounce or
+            // throttle filter that merely rescheduled its timer leaves the
+            // slot empty, and overwriting would destroy the value that the
+            // next invocation has to receive.
+            if callback_value.is_some() {
+                prev_callback_value.replace(callback_value);
+            }
         },
         options.immediate,
     );

--- a/tests/use_cycle_list.rs
+++ b/tests/use_cycle_list.rs
@@ -1,0 +1,56 @@
+use leptos::prelude::*;
+use leptos_use::{UseCycleListReturn, use_cycle_list};
+
+// The list is only checked for emptiness while the initial value is derived.
+// When a reactive list becomes empty afterwards, every cycling helper divided
+// by a zero length and panicked with
+// "attempt to calculate the remainder with a divisor of zero".
+#[test]
+fn cycling_an_emptied_list_does_not_panic() {
+    let owner = Owner::new();
+    owner.set();
+
+    let list = RwSignal::new(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+
+    let UseCycleListReturn {
+        state,
+        set_index,
+        next,
+        prev,
+        shift,
+        ..
+    } = use_cycle_list(list);
+
+    list.set(vec![]);
+
+    next();
+    prev();
+    shift(3);
+    shift(-3);
+    set_index(2);
+
+    assert_eq!(
+        state.get_untracked(),
+        "a".to_string(),
+        "state must stay untouched while the list is empty"
+    );
+}
+
+// Once the list is refilled the helpers have to resume cycling normally.
+#[test]
+fn cycling_resumes_after_the_list_is_refilled() {
+    let owner = Owner::new();
+    owner.set();
+
+    let list = RwSignal::new(vec!["a".to_string(), "b".to_string()]);
+
+    let UseCycleListReturn { state, next, .. } = use_cycle_list(list);
+
+    list.set(vec![]);
+    next();
+
+    list.set(vec!["a".to_string(), "b".to_string()]);
+    next();
+
+    assert_eq!(state.get_untracked(), "b".to_string());
+}

--- a/tests/use_user_media.rs
+++ b/tests/use_user_media.rs
@@ -1,0 +1,54 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos::web_sys::MediaStream;
+use leptos_use::{UseUserMediaOptions, UseUserMediaReturn, use_user_media_with_options};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// The hook stops the stream's tracks when `enabled` turns false or when the
+// returned `stop()` is called, but it never registered a cleanup handler.
+// Disposing the owner (unmounting the component) therefore left the camera and
+// microphone running for the lifetime of the page, with no handle left to stop
+// them.
+#[wasm_bindgen_test]
+async fn tracks_are_stopped_when_the_owner_is_cleaned_up() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let UseUserMediaReturn { stream, .. } =
+        use_user_media_with_options(UseUserMediaOptions::default().enabled(true.into()));
+
+    // Give `getUserMedia` a chance to resolve.
+    let mut media_stream: Option<MediaStream> = None;
+    for _ in 0..50 {
+        TimeoutFuture::new(100).await;
+
+        match stream.get_untracked() {
+            Some(Ok(s)) => {
+                media_stream = Some(s);
+                break;
+            }
+            Some(Err(err)) => panic!("getUserMedia failed: {err:?}"),
+            None => {}
+        }
+    }
+
+    let media_stream = media_stream.expect("the fake media stream should have started");
+
+    assert!(
+        media_stream.active(),
+        "the stream should be running before the owner is cleaned up"
+    );
+
+    owner.cleanup();
+
+    assert!(
+        !media_stream.active(),
+        "cleaning up the owner must stop the media tracks"
+    );
+}

--- a/tests/watch_debounced.rs
+++ b/tests/watch_debounced.rs
@@ -1,0 +1,63 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::watch_debounced;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// `watch_*` passes the callback's own previous return value as the third
+// argument. The bookkeeping cell was overwritten on every dependency change
+// with whatever the filter happened to be holding, even when the filter had
+// only rescheduled its timer without invoking the callback. Two rapid changes
+// inside one debounce window therefore destroyed the previous return value and
+// the callback saw `None` instead.
+#[wasm_bindgen_test]
+async fn debounced_watch_keeps_the_previous_return_value() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let (source, set_source) = signal(0);
+    let seen: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let _stop = watch_debounced(
+        move || source.get(),
+        {
+            let seen = Rc::clone(&seen);
+
+            move |_value, _prev_value, prev_return: Option<i32>| {
+                let next = prev_return.unwrap_or(0) + 1;
+                seen.borrow_mut().push(next);
+                next
+            }
+        },
+        100.0,
+    );
+
+    // Let the effect perform its initial run, which does not invoke the
+    // callback because `immediate` defaults to false.
+    TimeoutFuture::new(50).await;
+
+    // A single change that is allowed to settle: the callback runs once and
+    // returns 1.
+    set_source.set(1);
+    TimeoutFuture::new(400).await;
+
+    // Two changes inside one debounce window. Only the second one reaches the
+    // callback, and it has to see the 1 returned by the previous invocation.
+    set_source.set(2);
+    TimeoutFuture::new(20).await;
+    set_source.set(3);
+    TimeoutFuture::new(400).await;
+
+    assert_eq!(
+        *seen.borrow(),
+        vec![1, 2],
+        "the second invocation must receive the previous return value"
+    );
+}

--- a/webdriver.json
+++ b/webdriver.json
@@ -1,0 +1,14 @@
+{
+  "moz:firefoxOptions": {
+    "prefs": {
+      "media.navigator.streams.fake": true,
+      "media.navigator.permission.disabled": true
+    }
+  },
+  "goog:chromeOptions": {
+    "args": [
+      "--use-fake-device-for-media-stream",
+      "--use-fake-ui-for-media-stream"
+    ]
+  }
+}


### PR DESCRIPTION
### `use_cycle_list`: panic when the list becomes empty
`set()` and `shift()` divide by the list length without checking it, so
`next()`, `prev()`, `shift()` and `set_index()` panic with "attempt to calculate
the remainder with a divisor of zero" once a signal-backed list is emptied
(filtered/searched lists being the common case). The internal `Effect::watch`
calls `set()` on every list change, so the panic is reachable without user
interaction. Both helpers now no-op while the list is empty and resume when it
is refilled.

### `use_user_media` / `use_display_media`: devices not released on unmount
The `_stop` closure that stops the stream's tracks was only reachable through
the returned `stop()` or through `enabled` turning false. Neither hook
registered a cleanup handler, so unmounting a component (route change, `<Show/>`
toggling off) left the camera, microphone or screen capture running for the
lifetime of the page — with no remaining handle to stop it. The closure is now
registered with `on_cleanup` in non-`ssr` builds.

### `watch_with_options`: previous return value lost across filtered runs
The cell holding the callback's previous return value was overwritten
unconditionally, including when a debounce/throttle filter merely rescheduled
its timer and ran nothing — writing `None` over the pending value. Any burst of
two or more changes inside one debounce window silently reset the accumulated
value, affecting `watch_debounced`, `watch_throttled`, `whenever_with_options`
and `watch_pausable_with_options`. The value is now stored only when the
callback actually ran.