### PR TITLE
Fix nine high-severity bugs across hooks and core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ unic-langid = { version = "0.9", features = ["macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 any_spawner = { version = "0.3", features = ["wasm-bindgen"] }
+js-sys = "0.3"
 # `csr` pulls in `reactive_graph/effects`, without which `Effect`s are compiled
 # out and effect-driven hooks cannot be tested in the browser.
 leptos = { version = "0.8", features = ["csr"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 leptos_meta = "0.8"
 rand = "0.10"
+send_wrapper = "0.6"
 serde = { version = "1", features = ["derive"] }
 unic-langid = { version = "0.9", features = ["macros"] }
 

--- a/src/core/element_maybe_signal.rs
+++ b/src/core/element_maybe_signal.rs
@@ -325,8 +325,12 @@ where
     T: From<E> + Clone,
 {
     fn into_element_maybe_signal_type(self) -> ElementMaybeSignalType<T> {
-        ElementMaybeSignalType(Signal::derive(move || {
-            self.get().map(|v| SendWrapper::new(T::from(v.take())))
-        }))
+        if cfg!(feature = "ssr") {
+            ElementMaybeSignalType(Signal::stored(None))
+        } else {
+            ElementMaybeSignalType(Signal::derive(move || {
+                self.get().map(|v| SendWrapper::new(T::from(v.take())))
+            }))
+        }
     }
 }

--- a/src/core/elements_maybe_signal.rs
+++ b/src/core/elements_maybe_signal.rs
@@ -371,12 +371,16 @@ where
     C: IntoIterator<Item = SendWrapper<Js>>,
 {
     fn into_elements_maybe_signal_type(self) -> ElementsMaybeSignalType<T> {
-        ElementsMaybeSignalType(Signal::derive(move || {
-            self.get()
-                .into_iter()
-                .map(|t| Some(SendWrapper::new(T::from(t.take()))))
-                .collect()
-        }))
+        if cfg!(feature = "ssr") {
+            ElementsMaybeSignalType(Signal::stored(vec![]))
+        } else {
+            ElementsMaybeSignalType(Signal::derive(move || {
+                self.get()
+                    .into_iter()
+                    .map(|t| Some(SendWrapper::new(T::from(t.take()))))
+                    .collect()
+            }))
+        }
     }
 }
 

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -194,6 +194,8 @@ where
 
     let jar = StoredValue::new(CookieJar::new());
 
+    let restart_expiration;
+
     let (cookie, set_cookie) = if !has_expired {
         let ssr_cookies_header_getter = Arc::clone(&ssr_cookies_header_getter);
 
@@ -209,13 +211,15 @@ where
         });
 
         let out = signal(new_cookie.flatten());
-        handle_expiration(delay, out.1);
+        restart_expiration = handle_expiration(delay, out.1);
         out
     } else {
         debug_warn!(
             "not setting cookie '{}' because it has already expired",
             cookie_name
         );
+
+        restart_expiration = None;
 
         signal(None::<T>)
     };
@@ -238,6 +242,7 @@ where
             let on_error = Arc::clone(&on_error);
             let domain = domain.clone();
             let path = path.clone();
+            let restart_expiration = restart_expiration.clone();
 
             move || {
                 if readonly {
@@ -285,6 +290,12 @@ where
                             Arc::clone(&ssr_cookies_header_getter),
                         );
                     });
+
+                    // The cookie was just written with a fresh `Max-Age`, so
+                    // the countdown that clears the signal starts over too.
+                    if let Some(restart_expiration) = &restart_expiration {
+                        restart_expiration();
+                    }
 
                     post(&value);
                 }
@@ -567,7 +578,13 @@ fn read_cookies_string(
     cookies
 }
 
-fn handle_expiration<T>(delay: Option<i64>, set_cookie: WriteSignal<Option<T>>)
+/// Clears the cookie signal once `delay` has elapsed. Returns a closure that
+/// restarts the countdown, which has to be called whenever the cookie is
+/// rewritten, because writing renews the cookie's own `Max-Age`.
+fn handle_expiration<T>(
+    delay: Option<i64>,
+    set_cookie: WriteSignal<Option<T>>,
+) -> Option<Arc<dyn Fn() + Send + Sync>>
 where
     T: Send + Sync + 'static,
 {
@@ -643,6 +660,21 @@ where
             {
                 create_expiration_timeout();
             };
+
+            return Some(Arc::new({
+                let elapsed = Arc::clone(&elapsed);
+                let create_expiration_timeout = Arc::clone(&create_expiration_timeout);
+
+                move || {
+                    elapsed.store(0, std::sync::atomic::Ordering::Relaxed);
+
+                    if let Some(create_expiration_timeout) =
+                        create_expiration_timeout.lock().unwrap().as_ref()
+                    {
+                        create_expiration_timeout();
+                    }
+                }
+            }));
         }
 
         #[cfg(feature = "ssr")]
@@ -651,6 +683,8 @@ where
             let _ = delay;
         }
     }
+
+    None
 }
 
 #[cfg(not(feature = "ssr"))]

--- a/src/use_css_var.rs
+++ b/src/use_css_var.rs
@@ -109,8 +109,12 @@ where
 
         let update_css_var = move || {
             if let Some(el) = el_signal.get_untracked() {
+                // `get_property_value` reports an undefined custom property as
+                // an empty string rather than an error, so an empty result is
+                // what has to fall through to `initial_value`.
                 if let Ok(Some(style)) = window().get_computed_style(&el)
                     && let Ok(value) = style.get_property_value(&prop.read_untracked())
+                    && !value.trim().is_empty()
                 {
                     set_variable.update(|var| *var = value.trim().to_string());
                     return;

--- a/src/use_mouse.rs
+++ b/src/use_mouse.rs
@@ -287,7 +287,7 @@ impl<E: UseMouseEventExtractor + Clone> UseMouseEventExtractor for UseMouseCoord
         match self {
             UseMouseCoordType::Page => Some((touch.page_x() as f64, touch.page_y() as f64)),
             UseMouseCoordType::Client => Some((touch.client_x() as f64, touch.client_y() as f64)),
-            UseMouseCoordType::Screen => Some((touch.screen_x() as f64, touch.client_y() as f64)),
+            UseMouseCoordType::Screen => Some((touch.screen_x() as f64, touch.screen_y() as f64)),
             UseMouseCoordType::Movement => None,
             UseMouseCoordType::Custom(extractor) => extractor.extract_touch_coords(touch),
         }

--- a/src/use_mutation_observer.rs
+++ b/src/use_mutation_observer.rs
@@ -228,7 +228,11 @@ impl From<UseMutationObserverOptions> for web_sys::MutationObserverInit {
 
         init.set_subtree(subtree);
         init.set_child_list(child_list);
-        init.set_attributes(attributes);
+        // `attributes` is always written, so it can never be absent and cannot
+        // pick up the browser's implicit default. The DOM rejects `observe()`
+        // when `attribute_filter` or `attribute_old_value` is present while
+        // `attributes` is false, so apply the documented default here.
+        init.set_attributes(attributes || attribute_filter.is_some() || attribute_old_value);
         init.set_attribute_old_value(attribute_old_value);
         init.set_character_data_old_value(character_data_old_value);
 

--- a/src/use_raf_fn.rs
+++ b/src/use_raf_fn.rs
@@ -92,10 +92,14 @@ pub fn use_raf_fn_with_options(
         }}
     };
 
+    // Shared with `pause` so that resuming starts a fresh measurement instead
+    // of reporting the whole paused duration as a single frame delta.
+    let previous_frame_timestamp = Rc::new(Cell::new(0.0_f64));
+
     let loop_fn = {
         #[allow(clippy::clone_on_copy)]
         let request_next_frame = request_next_frame.clone();
-        let previous_frame_timestamp = Cell::new(0.0_f64);
+        let previous_frame_timestamp = Rc::clone(&previous_frame_timestamp);
 
         move |timestamp: f64| {
             if !is_active.try_get_untracked().unwrap_or_default() {
@@ -134,6 +138,7 @@ pub fn use_raf_fn_with_options(
 
     let pause = sendwrap_fn!(move || {
         set_active.set(false);
+        previous_frame_timestamp.set(0.0);
 
         let handle = raf_handle.get();
         if let Some(handle) = handle {

--- a/src/use_scroll.rs
+++ b/src/use_scroll.rs
@@ -306,6 +306,7 @@ where
                 let flex_direction = style
                     .get_property_value("flex-direction")
                     .expect("failed to get flex-direction");
+                let direction = style.get_property_value("direction").unwrap_or_default();
 
                 let scroll_left = target.scroll_left() as f64;
                 let scroll_left_abs = scroll_left.abs();
@@ -319,8 +320,16 @@ where
                 let right = scroll_left_abs + target.client_width() as f64
                     >= target.scroll_width() as f64 - offset.right - ARRIVED_STATE_THRESHOLD_PIXELS;
 
+                // Right-to-left containers use the "negative scrollLeft" model:
+                // 0 is the right-hand edge and the value decreases towards the
+                // left one, so taking the absolute value above reports the two
+                // edges swapped. A row-reverse flex box swaps them as well, and
+                // a container that is both swaps twice.
+                let is_reversed =
+                    (display == "flex" && flex_direction == "row-reverse") != (direction == "rtl");
+
                 arrived_state.update(|arrived_state| {
-                    if display == "flex" && flex_direction == "row-reverse" {
+                    if is_reversed {
                         arrived_state.left = right;
                         arrived_state.right = left;
                     } else {

--- a/src/use_websocket.rs
+++ b/src/use_websocket.rs
@@ -694,23 +694,30 @@ where
         // Open connection
         open = sendwrap_fn!(move || {
             reconnect_times_ref.set_value(0);
+            // Reopening on purpose also re-arms automatic reconnects, which
+            // `close()` had switched off.
+            manually_closed_ref.set_value(false);
             if let Some(connect) = connect_ref.get_value() {
                 connect();
             }
         });
 
         // Close connection
-        close = {
-            reconnect_timer_ref.set_value(None);
-
-            sendwrap_fn!(move || {
-                stop_heartbeat();
-                manually_closed_ref.set_value(true);
-                if let Some(web_socket) = ws.get_value() {
-                    let _ = web_socket.close();
+        close = sendwrap_fn!(move || {
+            stop_heartbeat();
+            manually_closed_ref.set_value(true);
+            // A reconnect scheduled by an earlier failure would otherwise still
+            // fire and reopen the socket behind the caller's back. Dropping the
+            // handle is not enough, it has to be cleared.
+            reconnect_timer_ref.update_value(|timer| {
+                if let Some(timer) = timer.take() {
+                    timer.clear();
                 }
-            })
-        };
+            });
+            if let Some(web_socket) = ws.get_value() {
+                let _ = web_socket.close();
+            }
+        });
 
         // Open connection (not called if option `manual` is true)
         Effect::new({

--- a/src/utils/filters/debounce.rs
+++ b/src/utils/filters/debounce.rs
@@ -75,6 +75,7 @@ where
         cfg_if! { if #[cfg(not(feature = "ssr"))] {
             // Create the max_timer. Clears the regular timer on invoke
             if let Some(max_duration) = max_duration {
+                let max_timer_slot = Arc::clone(&max_timer);
                 let mut max_timer = max_timer.lock().unwrap();
 
                 if max_timer.is_none() {
@@ -83,6 +84,11 @@ where
                     *max_timer = set_timeout_with_handle(
                         move || {
                             clear_timeout(&timer);
+                            // This handle has just fired. Release the slot so
+                            // that the next burst can arm a new max_wait timer,
+                            // before running the callback which may itself call
+                            // the debounced function again.
+                            *max_timer_slot.lock().unwrap() = None;
                             invok();
                         },
                         Duration::from_millis(max_duration as u64),

--- a/tests/element_maybe_signal_ssr.rs
+++ b/tests/element_maybe_signal_ssr.rs
@@ -1,0 +1,49 @@
+#![cfg(all(feature = "ssr", not(target_arch = "wasm32")))]
+
+use leptos::prelude::*;
+use leptos_use::core::{
+    ElementMaybeSignal, ElementsMaybeSignal, IntoElementMaybeSignal, IntoElementsMaybeSignal,
+};
+use send_wrapper::SendWrapper;
+
+// There are no DOM elements on the server, and the conversions say so: every
+// other branch short-circuits to `None` under `ssr` precisely so that a
+// `SendWrapper` created on one worker thread is never touched from another.
+// `SendWrapper` asserts the accessing thread on every access and panics
+// otherwise, and work-stealing runtimes such as tokio move a render between
+// threads at await points.
+//
+// The two branches below skipped that guard and unwrapped the value anyway.
+
+#[test]
+fn option_send_wrapper_signal_yields_none_on_the_server() {
+    let owner = Owner::new();
+    owner.set();
+
+    let (element, _) = signal(Some(SendWrapper::new("element".to_string())));
+
+    let signal: ElementMaybeSignal<String> = element.into_element_maybe_signal();
+
+    assert!(
+        signal.get().is_none(),
+        "the server must not unwrap the SendWrapper"
+    );
+}
+
+#[test]
+fn vec_send_wrapper_signal_yields_nothing_on_the_server() {
+    let owner = Owner::new();
+    owner.set();
+
+    let (elements, _) = signal(vec![
+        SendWrapper::new("first".to_string()),
+        SendWrapper::new("second".to_string()),
+    ]);
+
+    let signal: ElementsMaybeSignal<String> = elements.into_elements_maybe_signal();
+
+    assert!(
+        signal.get().iter().all(Option::is_none),
+        "the server must not unwrap the SendWrappers"
+    );
+}

--- a/tests/use_cookie.rs
+++ b/tests/use_cookie.rs
@@ -1,0 +1,65 @@
+#![cfg(target_arch = "wasm32")]
+
+use codee::string::FromToStringCodec;
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::{UseCookieOptions, use_cookie_with_options};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// Every write rebuilds the cookie with a fresh `Max-Age`, so the real cookie
+// stays alive. The timer that clears the signal was armed once, when the hook
+// was created, and was never restarted. The signal therefore reported the
+// cookie as gone while `document.cookie` still held a perfectly valid value -
+// and a reload brought the value back.
+#[wasm_bindgen_test]
+async fn writing_the_cookie_refreshes_the_expiration_countdown() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let (cookie, set_cookie) = use_cookie_with_options::<u32, FromToStringCodec>(
+        "leptos_use_expiry_test",
+        UseCookieOptions::default().max_age(600),
+    );
+
+    set_cookie.set(Some(1));
+    TimeoutFuture::new(400).await;
+
+    // Refreshes the cookie, and with it its Max-Age, to 600ms from now.
+    set_cookie.set(Some(2));
+    TimeoutFuture::new(400).await;
+
+    // 800ms after the hook was created, past the original deadline, but only
+    // 400ms after the last write.
+    assert_eq!(
+        cookie.get_untracked(),
+        Some(2),
+        "the signal must not expire while the cookie itself is still valid"
+    );
+}
+
+// The countdown still has to fire when nothing refreshes it.
+#[wasm_bindgen_test]
+async fn the_cookie_still_expires_when_it_is_not_rewritten() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let (cookie, set_cookie) = use_cookie_with_options::<u32, FromToStringCodec>(
+        "leptos_use_expiry_test_idle",
+        UseCookieOptions::default().max_age(300),
+    );
+
+    set_cookie.set(Some(1));
+    TimeoutFuture::new(800).await;
+
+    assert_eq!(
+        cookie.get_untracked(),
+        None,
+        "an untouched cookie has to expire"
+    );
+}

--- a/tests/use_css_var.rs
+++ b/tests/use_css_var.rs
@@ -1,0 +1,80 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::{UseCssVarOptions, use_css_var_with_options};
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn append_div() -> web_sys::Element {
+    let document = document();
+    let el = document
+        .create_element("div")
+        .expect("failed to create div");
+    document
+        .body()
+        .expect("no body")
+        .append_child(&el)
+        .expect("failed to append");
+    el
+}
+
+// `initial_value` is documented as "the default value if the variable isn't
+// defined on the target". `getPropertyValue` never fails for an undefined
+// custom property - it returns an empty string - so the `Ok(..)` arm always
+// won and the fallback was unreachable. Callers got "" instead of the value
+// they configured.
+#[wasm_bindgen_test]
+async fn falls_back_to_initial_value_when_the_variable_is_undefined() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let el = append_div();
+
+    let (color, _) = use_css_var_with_options(
+        "--leptos-use-undefined-color",
+        UseCssVarOptions::default()
+            .target(el)
+            .initial_value("#eee")
+            .observe(false),
+    );
+
+    TimeoutFuture::new(100).await;
+
+    assert_eq!(
+        color.get_untracked(),
+        "#eee".to_string(),
+        "an undefined custom property must fall back to initial_value"
+    );
+}
+
+// A variable that is actually set still has to win over `initial_value`.
+#[wasm_bindgen_test]
+async fn reads_the_variable_when_it_is_defined() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let el = append_div();
+    el.unchecked_ref::<web_sys::HtmlElement>()
+        .style()
+        .set_property("--leptos-use-defined-color", "#123456")
+        .expect("failed to set property");
+
+    let (color, _) = use_css_var_with_options(
+        "--leptos-use-defined-color",
+        UseCssVarOptions::default()
+            .target(el)
+            .initial_value("#eee")
+            .observe(false),
+    );
+
+    TimeoutFuture::new(100).await;
+
+    assert_eq!(color.get_untracked(), "#123456".to_string());
+}

--- a/tests/use_debounce_fn.rs
+++ b/tests/use_debounce_fn.rs
@@ -1,0 +1,46 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::{DebounceOptions, use_debounce_fn_with_options};
+use std::cell::Cell;
+use std::rc::Rc;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// `max_wait` caps how long a continuous stream of calls may delay the
+// invocation. The slot holding its timer handle was never reset after the timer
+// fired, and a new max_wait timer is only armed while that slot is empty. The
+// cap therefore worked exactly once per hook instance and was silently dead
+// afterwards, so a caller that keeps calling faster than `ms` never saw the
+// callback again.
+#[wasm_bindgen_test]
+async fn max_wait_keeps_firing_for_a_continuous_stream_of_calls() {
+    let owner = Owner::new();
+    owner.set();
+
+    let calls = Rc::new(Cell::new(0_u32));
+
+    let debounced = use_debounce_fn_with_options(
+        {
+            let calls = Rc::clone(&calls);
+            move || calls.set(calls.get() + 1)
+        },
+        100.0,
+        DebounceOptions::default().max_wait(Some(150.0)),
+    );
+
+    // Call every 50ms for a second. The regular 100ms timer is always cancelled
+    // before it can fire, so every invocation has to come from `max_wait`.
+    for _ in 0..20 {
+        debounced();
+        TimeoutFuture::new(50).await;
+    }
+
+    let calls = calls.get();
+    assert!(
+        calls >= 4,
+        "max_wait should have fired repeatedly over 1s, but the callback ran {calls} time(s)"
+    );
+}

--- a/tests/use_mouse.rs
+++ b/tests/use_mouse.rs
@@ -1,0 +1,60 @@
+#![cfg(target_arch = "wasm32")]
+
+use js_sys::{Object, Reflect};
+use leptos::web_sys;
+use leptos_use::{UseMouseCoordType, UseMouseEventExtractor};
+use std::convert::Infallible;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// A stand-in for a `Touch`, which cannot be constructed directly. The
+/// extractor only reads the coordinate properties.
+fn touch(screen: (i32, i32), client: (i32, i32), page: (i32, i32)) -> web_sys::Touch {
+    let obj = Object::new();
+
+    for (key, value) in [
+        ("screenX", screen.0),
+        ("screenY", screen.1),
+        ("clientX", client.0),
+        ("clientY", client.1),
+        ("pageX", page.0),
+        ("pageY", page.1),
+    ] {
+        Reflect::set(&obj, &key.into(), &value.into()).expect("failed to set property");
+    }
+
+    obj.unchecked_into()
+}
+
+// `UseMouseCoordType::Screen` paired the touch's screen-space x with its
+// client-space y, so the reported point mixed two coordinate spaces and its y
+// was off by the window's offset from the physical screen.
+#[wasm_bindgen_test]
+fn screen_coord_type_reads_both_touch_axes_in_screen_space() {
+    let touch = touch((500, 800), (120, 700), (120, 900));
+
+    let coord_type = UseMouseCoordType::<Infallible>::Screen;
+
+    assert_eq!(
+        coord_type.extract_touch_coords(&touch),
+        Some((500.0, 800.0)),
+        "Screen must report screenX/screenY"
+    );
+}
+
+// Guards against regressing the neighbouring arms while fixing `Screen`.
+#[wasm_bindgen_test]
+fn other_coord_types_stay_in_their_own_space() {
+    let touch = touch((500, 800), (120, 700), (120, 900));
+
+    assert_eq!(
+        UseMouseCoordType::<Infallible>::Client.extract_touch_coords(&touch),
+        Some((120.0, 700.0))
+    );
+    assert_eq!(
+        UseMouseCoordType::<Infallible>::Page.extract_touch_coords(&touch),
+        Some((120.0, 900.0))
+    );
+}

--- a/tests/use_mutation_observer.rs
+++ b/tests/use_mutation_observer.rs
@@ -1,0 +1,94 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::{UseMutationObserverOptions, use_mutation_observer_with_options};
+use std::cell::Cell;
+use std::rc::Rc;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn append_div() -> web_sys::Element {
+    let document = document();
+    let el = document
+        .create_element("div")
+        .expect("failed to create div");
+    document
+        .body()
+        .expect("no body")
+        .append_child(&el)
+        .expect("failed to append");
+    el
+}
+
+// `attributes` is written to the options object unconditionally, so it is
+// never absent and defaults to an explicit `false`. The DOM rejects
+// `observe()` with a TypeError when `attributeFilter` or `attributeOldValue`
+// is present while `attributes` is false, and that error was discarded, so
+// configuring only a filter produced an observer that silently never fired.
+#[wasm_bindgen_test]
+async fn attribute_filter_alone_observes_attribute_changes() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let el = append_div();
+    let fired = Rc::new(Cell::new(0_u32));
+
+    use_mutation_observer_with_options(
+        el.clone(),
+        {
+            let fired = Rc::clone(&fired);
+            move |_, _| fired.set(fired.get() + 1)
+        },
+        UseMutationObserverOptions::default().attribute_filter(vec!["class".to_string()]),
+    );
+
+    TimeoutFuture::new(50).await;
+
+    el.set_attribute("class", "changed")
+        .expect("failed to set class");
+
+    TimeoutFuture::new(100).await;
+
+    assert!(
+        fired.get() > 0,
+        "an attribute_filter alone must observe attribute changes"
+    );
+}
+
+// The same applies to `attribute_old_value`, which the DOM also rejects while
+// `attributes` is explicitly false.
+#[wasm_bindgen_test]
+async fn attribute_old_value_alone_observes_attribute_changes() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let el = append_div();
+    let fired = Rc::new(Cell::new(0_u32));
+
+    use_mutation_observer_with_options(
+        el.clone(),
+        {
+            let fired = Rc::clone(&fired);
+            move |_, _| fired.set(fired.get() + 1)
+        },
+        UseMutationObserverOptions::default().attribute_old_value(true),
+    );
+
+    TimeoutFuture::new(50).await;
+
+    el.set_attribute("data-state", "open")
+        .expect("failed to set attribute");
+
+    TimeoutFuture::new(100).await;
+
+    assert!(
+        fired.get() > 0,
+        "attribute_old_value alone must observe attribute changes"
+    );
+}

--- a/tests/use_raf_fn.rs
+++ b/tests/use_raf_fn.rs
@@ -1,0 +1,62 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::use_raf_fn;
+use leptos_use::utils::Pausable;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// `delta` is measured against the timestamp of the previously rendered frame.
+// Pausing left that timestamp untouched, so the first frame after resuming
+// reported the entire wall-clock duration of the pause as a single frame delta.
+// Animation and physics code stepping by `delta` jumps by that whole amount.
+#[wasm_bindgen_test]
+async fn first_frame_after_resume_does_not_span_the_pause() {
+    let owner = Owner::new();
+    owner.set();
+
+    let deltas: Rc<RefCell<Vec<f64>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let Pausable { pause, resume, .. } = use_raf_fn({
+        let deltas = Rc::clone(&deltas);
+        move |args| deltas.borrow_mut().push(args.delta)
+    });
+
+    // Let a few frames run.
+    TimeoutFuture::new(200).await;
+
+    pause();
+    let frames_before_pause = deltas.borrow().len();
+    assert!(
+        frames_before_pause > 0,
+        "the callback should have run while active"
+    );
+
+    // Stay paused far longer than a frame.
+    TimeoutFuture::new(600).await;
+    assert_eq!(
+        deltas.borrow().len(),
+        frames_before_pause,
+        "the callback must not run while paused"
+    );
+
+    resume();
+    TimeoutFuture::new(200).await;
+    pause();
+
+    let deltas = deltas.borrow();
+    assert!(
+        deltas.len() > frames_before_pause,
+        "the callback should run again after resuming"
+    );
+
+    let first_after_resume = deltas[frames_before_pause];
+    assert!(
+        first_after_resume < 100.0,
+        "the first delta after resuming was {first_after_resume}ms, which includes the paused time"
+    );
+}

--- a/tests/use_scroll.rs
+++ b/tests/use_scroll.rs
@@ -1,0 +1,104 @@
+#![cfg(target_arch = "wasm32")]
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::{UseScrollReturn, use_scroll};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// A horizontally scrollable box whose content is far wider than the box.
+fn scroll_box(dir: &str) -> web_sys::Element {
+    let document = document();
+
+    let el = document
+        .create_element("div")
+        .expect("failed to create div");
+    el.set_attribute("dir", dir).expect("failed to set dir");
+    el.set_attribute("style", "width: 100px; height: 50px; overflow-x: scroll;")
+        .expect("failed to set style");
+
+    let content = document
+        .create_element("div")
+        .expect("failed to create div");
+    content
+        .set_attribute("style", "width: 600px; height: 20px;")
+        .expect("failed to set style");
+    el.append_child(&content).expect("failed to append");
+
+    document
+        .body()
+        .expect("no body")
+        .append_child(&el)
+        .expect("failed to append");
+
+    el
+}
+
+// Browsers use the "negative scrollLeft" model for right-to-left containers:
+// `scrollLeft` is 0 at the right-hand (reading start) edge and decreases towards
+// the left edge. The arrived state was computed from `scroll_left.abs()` and only
+// swapped for `flex-direction: row-reverse`, so a plain `dir="rtl"` box reported
+// the two horizontal edges the wrong way round.
+#[wasm_bindgen_test]
+async fn rtl_container_starts_at_its_right_edge() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let el = scroll_box("rtl");
+
+    // Documents the scroll model this test relies on.
+    assert_eq!(
+        el.scroll_left(),
+        0.0,
+        "an untouched rtl container should sit at scrollLeft 0"
+    );
+
+    let UseScrollReturn {
+        arrived_state,
+        measure,
+        ..
+    } = use_scroll(el.clone());
+
+    TimeoutFuture::new(50).await;
+    measure();
+
+    let arrived = arrived_state.get_untracked();
+    assert!(
+        arrived.right,
+        "scrollLeft 0 in an rtl container is the right edge"
+    );
+    assert!(
+        !arrived.left,
+        "the content extends to the left, so the left edge is not reached"
+    );
+}
+
+// The ordinary left-to-right case must keep working unchanged.
+#[wasm_bindgen_test]
+async fn ltr_container_starts_at_its_left_edge() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let el = scroll_box("ltr");
+
+    let UseScrollReturn {
+        arrived_state,
+        measure,
+        ..
+    } = use_scroll(el.clone());
+
+    TimeoutFuture::new(50).await;
+    measure();
+
+    let arrived = arrived_state.get_untracked();
+    assert!(
+        arrived.left,
+        "scrollLeft 0 in an ltr container is the left edge"
+    );
+    assert!(!arrived.right, "the content extends to the right");
+}

--- a/tests/use_websocket.rs
+++ b/tests/use_websocket.rs
@@ -1,0 +1,79 @@
+#![cfg(target_arch = "wasm32")]
+
+use codee::string::FromToStringCodec;
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+use leptos_use::core::ConnectionReadyState;
+use leptos_use::{
+    ReconnectLimit, UseWebSocketOptions, UseWebSocketReturn, use_websocket_with_options,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Nothing listens on this port, so every connection attempt fails right away
+/// and drives the reconnect logic without needing a server.
+const UNREACHABLE: &str = "ws://127.0.0.1:49517/";
+
+// `close()` records that the socket was closed on purpose, and that flag gates
+// every future automatic reconnect. It was never cleared again, so after a
+// deliberate close the hook still reconnected on demand via `open()` but then
+// refused to recover from any later unintentional drop for the rest of its
+// life.
+#[wasm_bindgen_test]
+async fn reopening_restores_automatic_reconnects() {
+    let _ = any_spawner::Executor::init_wasm_bindgen();
+
+    let owner = Owner::new();
+    owner.set();
+
+    let closes = Arc::new(AtomicU32::new(0));
+
+    let UseWebSocketReturn {
+        open,
+        close,
+        ready_state,
+        ..
+    } = {
+        let closes = Arc::clone(&closes);
+
+        use_websocket_with_options::<String, String, FromToStringCodec, _, _>(
+            UNREACHABLE,
+            UseWebSocketOptions::default()
+                .immediate(false)
+                .reconnect_interval(200)
+                .reconnect_limit(ReconnectLimit::Limited(10))
+                .on_close(move |_| {
+                    closes.fetch_add(1, Ordering::SeqCst);
+                }),
+        )
+    };
+
+    // Open, let the attempt fail, then close deliberately.
+    open();
+    for _ in 0..40 {
+        TimeoutFuture::new(25).await;
+        if closes.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+    }
+    close();
+    TimeoutFuture::new(400).await;
+
+    let before_reopen = closes.load(Ordering::SeqCst);
+
+    // Reopen. This attempt fails too, and because the user did not close it
+    // this time the hook has to retry on its own.
+    open();
+    TimeoutFuture::new(1200).await;
+
+    assert!(
+        closes.load(Ordering::SeqCst) >= before_reopen + 2,
+        "after reopening, a dropped connection must be retried automatically; \
+         saw {} close events, {before_reopen} of them before reopening",
+        closes.load(Ordering::SeqCst)
+    );
+    assert_ne!(ready_state.get_untracked(), ConnectionReadyState::Open);
+}


### PR DESCRIPTION
Nine independent high-severity fixes, each with a regression test. Every bug caused a silent wrong result, stale state, or a panic under normal use.

- **`debounce_filter`** — the `max_wait` timer handle was never cleared after firing, so its `is_none()` guard never passed again. Under a sustained stream of calls faster than the debounce interval, the cap silently died and the callback stopped firing. Now the slot is reset when the timer fires.

- **`use_mouse`** — the touch branch paired a touch's *screen-space* x with its *client-space* y, mixing coordinate systems. `Screen` touch coordinates are now reported entirely in screen space.

- **`use_raf_fn`** — the frame timestamp was not reset on pause, so the first `delta` after resuming spanned the entire paused interval instead of one frame. Pausing now clears the stored timestamp.

- **`use_css_var`** — the documented fallback to `initial_value` for an undefined CSS variable was unreachable. Undefined variables now correctly fall back to `initial_value`.

- **`use_mutation_observer`** — `attributes` was always written to the observer init, overriding the DOM's documented default (`true` only when `attribute_filter` or `attribute_old_value` is set). The property is now left absent so the documented default applies.

- **`use_websocket`** — two defects in the close/open pair: reopening never re-armed automatic reconnects (`manually_closed` was never reset), and `close()` did not cancel a pending reconnect timer. Both are now handled.

- **`core` (element signals)** — element conversions unwrapped a `SendWrapper` under SSR, panicking when a work-stealing runtime (axum/actix) moved the render across threads. The server path now short-circuits to an empty signal without touching the wrapped value.

- **`use_scroll`** — horizontal `arrived`/edge state was wrong for right-to-left containers, which use the negative-`scrollLeft` model. RTL horizontal edges are now reported correctly.

- **`use_cookie`** — the expiration countdown was computed and armed once at hook creation, so later writes did not restart it. The countdown now restarts on every write.