### PR TITLE
Use passive event listeners where possible

### DIFF
--- a/src/on_click_outside.rs
+++ b/src/on_click_outside.rs
@@ -5,7 +5,7 @@ use default_struct_builder::DefaultBuilder;
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use leptos::prelude::*;
     use crate::utils::IS_IOS;
-    use crate::{use_event_listener, use_event_listener_with_options, UseEventListenerOptions, sendwrap_fn};
+    use crate::{UseEventListenerOptions, sendwrap_fn, use_event_listener_with_options};
     use leptos::ev::{blur, click, pointerdown};
     use std::cell::Cell;
     use std::rc::Rc;
@@ -207,7 +207,7 @@ where
         };
 
         let remove_blur_listener = if detect_iframes {
-            Some(use_event_listener::<_, web_sys::Window, _, _>(
+            Some(use_event_listener_with_options::<_, web_sys::Window, _, _>(
                 window(),
                 blur,
                 move |event| {
@@ -228,6 +228,7 @@ where
                         Duration::ZERO,
                     );
                 },
+                UseEventListenerOptions::default().passive(true),
             ))
         } else {
             None

--- a/src/storage/use_storage.rs
+++ b/src/storage/use_storage.rs
@@ -197,7 +197,8 @@ where
     #[cfg(not(feature = "ssr"))]
     {
         use crate::{
-            WatchOptions, sendwrap_fn, use_event_listener, use_window, watch_with_options,
+            UseEventListenerOptions, WatchOptions, sendwrap_fn, use_event_listener_with_options,
+            use_window, watch_with_options,
         };
         use send_wrapper::SendWrapper;
 
@@ -369,20 +370,26 @@ where
         }
 
         if listen_to_storage_changes {
+            let listener_options = UseEventListenerOptions::default().passive(true);
             // Listen to global storage events
-            let _ = use_event_listener(use_window(), leptos::ev::storage, {
-                let notify = notify.clone();
+            let _ = use_event_listener_with_options(
+                use_window(),
+                leptos::ev::storage,
+                {
+                    let notify = notify.clone();
 
-                move |ev| {
-                    let ev_key = ev.key();
-                    // Key matches or all keys deleted (None)
-                    if ev_key == Some(key.get_untracked()) || ev_key.is_none() {
-                        notify.notify()
+                    move |ev| {
+                        let ev_key = ev.key();
+                        // Key matches or all keys deleted (None)
+                        if ev_key == Some(key.get_untracked()) || ev_key.is_none() {
+                            notify.notify()
+                        }
                     }
-                }
-            });
+                },
+                listener_options,
+            );
             // Listen to internal storage events
-            let _ = use_event_listener(
+            let _ = use_event_listener_with_options(
                 use_window(),
                 leptos::ev::Custom::new(INTERNAL_STORAGE_EVENT),
                 {
@@ -394,6 +401,7 @@ where
                         }
                     }
                 },
+                listener_options,
             );
         };
 

--- a/src/use_active_element.rs
+++ b/src/use_active_element.rs
@@ -43,7 +43,9 @@ pub fn use_active_element() -> OptionLocalSignal<web_sys::Element> {
         active_element.set(Some(cur_active_element));
     }
 
-    let listener_options = UseEventListenerOptions::default().capture(true);
+    let listener_options = UseEventListenerOptions::default()
+        .capture(true)
+        .passive(true);
 
     let _ = use_event_listener_with_options(
         use_window(),

--- a/src/use_broadcast_channel.rs
+++ b/src/use_broadcast_channel.rs
@@ -1,6 +1,6 @@
 use crate::core::OptionLocalRwSignal;
 use crate::{
-    UseEventListenerOptions, core::OptionLocalSignal, js, sendwrap_fn, use_event_listener,
+    UseEventListenerOptions, core::OptionLocalSignal, js, sendwrap_fn,
     use_event_listener_with_options, use_supported,
 };
 use codee::{CodecError, Decoder, Encoder};
@@ -167,9 +167,12 @@ where
                         UseEventListenerOptions::default().passive(true),
                     );
 
-                    let _ = use_event_listener(channel, leptos::ev::close, move |_| {
-                        set_closed.set(true)
-                    });
+                    let _ = use_event_listener_with_options(
+                        channel,
+                        leptos::ev::close,
+                        move |_| set_closed.set(true),
+                        UseEventListenerOptions::default().passive(true),
+                    );
                 }
             }
         }

--- a/src/use_clipboard.rs
+++ b/src/use_clipboard.rs
@@ -1,4 +1,7 @@
-use crate::{UseTimeoutFnReturn, js, js_fut, sendwrap_fn, use_event_listener, use_supported};
+use crate::{
+    UseEventListenerOptions, UseTimeoutFnReturn, js, js_fut, sendwrap_fn,
+    use_event_listener_with_options, use_supported,
+};
 use default_struct_builder::DefaultBuilder;
 use leptos::ev::{copy, cut};
 use leptos::prelude::*;
@@ -94,8 +97,9 @@ pub fn use_clipboard_with_options(
     };
 
     if is_supported.get_untracked() && read {
-        let _ = use_event_listener(window(), copy, update_text);
-        let _ = use_event_listener(window(), cut, update_text);
+        let listener_options = UseEventListenerOptions::default().passive(true);
+        let _ = use_event_listener_with_options(window(), copy, update_text, listener_options);
+        let _ = use_event_listener_with_options(window(), cut, update_text, listener_options);
     }
 
     let do_copy = {

--- a/src/use_document_visibility.rs
+++ b/src/use_document_visibility.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "ssr", allow(unused_variables, unused_imports))]
 
-use crate::use_event_listener;
+use crate::{UseEventListenerOptions, use_event_listener_with_options};
 use cfg_if::cfg_if;
 use leptos::ev::visibilitychange;
 use leptos::prelude::*;
@@ -41,9 +41,14 @@ pub fn use_document_visibility() -> Signal<web_sys::VisibilityState> {
     let (visibility, set_visibility) = signal(inital_visibility);
 
     cfg_if! { if #[cfg(not(feature = "ssr"))] {
-        let _ = use_event_listener(document(), visibilitychange, move |_| {
-            set_visibility.set(document().visibility_state());
-        });
+        let _ = use_event_listener_with_options(
+            document(),
+            visibilitychange,
+            move |_| {
+                set_visibility.set(document().visibility_state());
+            },
+            UseEventListenerOptions::default().passive(true),
+        );
     }}
 
     visibility.into()

--- a/src/use_draggable.rs
+++ b/src/use_draggable.rs
@@ -201,25 +201,77 @@ where
 
     let dragging_element = dragging_element.into_element_maybe_signal();
 
-    let listener_options = UseEventListenerOptions::default().capture(true);
+    let passive_dragging_handle = Signal::derive(move || {
+        if prevent_default.get() {
+            None
+        } else {
+            dragging_handle.get()
+        }
+    });
+    let non_passive_dragging_handle = Signal::derive(move || {
+        if prevent_default.get() {
+            dragging_handle.get()
+        } else {
+            None
+        }
+    });
+    let passive_dragging_element = Signal::derive(move || {
+        if prevent_default.get() {
+            None
+        } else {
+            dragging_element.get()
+        }
+    });
+    let non_passive_dragging_element = Signal::derive(move || {
+        if prevent_default.get() {
+            dragging_element.get()
+        } else {
+            None
+        }
+    });
+
+    let passive_listener_options = UseEventListenerOptions::default()
+        .capture(true)
+        .passive(true);
+    let non_passive_listener_options = UseEventListenerOptions::default()
+        .capture(true)
+        .passive(false);
 
     let _ = use_event_listener_with_options(
-        dragging_handle,
+        passive_dragging_handle,
+        pointerdown,
+        on_pointer_down.clone(),
+        passive_listener_options,
+    );
+    let _ = use_event_listener_with_options(
+        non_passive_dragging_handle,
         pointerdown,
         on_pointer_down,
-        listener_options,
+        non_passive_listener_options,
     );
     let _ = use_event_listener_with_options(
-        dragging_element,
+        passive_dragging_element,
+        pointermove,
+        on_pointer_move.clone(),
+        passive_listener_options,
+    );
+    let _ = use_event_listener_with_options(
+        non_passive_dragging_element,
         pointermove,
         on_pointer_move,
-        listener_options,
+        non_passive_listener_options,
     );
     let _ = use_event_listener_with_options(
-        dragging_element,
+        passive_dragging_element,
+        pointerup,
+        on_pointer_up.clone(),
+        passive_listener_options,
+    );
+    let _ = use_event_listener_with_options(
+        non_passive_dragging_element,
         pointerup,
         on_pointer_up,
-        listener_options,
+        non_passive_listener_options,
     );
 
     UseDraggableReturn {

--- a/src/use_idle.rs
+++ b/src/use_idle.rs
@@ -104,8 +104,7 @@ pub fn use_idle_with_options(
     {
         use crate::utils::create_filter_wrapper;
         use crate::{
-            UseEventListenerOptions, sendwrap_fn, use_document, use_event_listener,
-            use_event_listener_with_options,
+            UseEventListenerOptions, sendwrap_fn, use_document, use_event_listener_with_options,
         };
         use leptos::ev::{Custom, visibilitychange};
         use leptos::leptos_dom::helpers::TimeoutHandle;
@@ -158,11 +157,16 @@ pub fn use_idle_with_options(
         if listen_for_visibility_change {
             let on_event = on_event.clone();
 
-            let _ = use_event_listener(use_document(), visibilitychange, move |evt| {
-                if !document().hidden() {
-                    on_event(evt);
-                }
-            });
+            let _ = use_event_listener_with_options(
+                use_document(),
+                visibilitychange,
+                move |evt| {
+                    if !document().hidden() {
+                        on_event(evt);
+                    }
+                },
+                listener_options,
+            );
         }
 
         reset.clone()();

--- a/src/use_locales.rs
+++ b/src/use_locales.rs
@@ -66,10 +66,14 @@ pub fn use_locales_with_options(options: UseLocalesOptions) -> Signal<Vec<String
 
         let (locales, set_locales) = signal(read_navigator_languages());
 
-        let _ =
-            crate::use_event_listener(crate::use_window(), leptos::ev::languagechange, move |_| {
+        let _ = crate::use_event_listener_with_options(
+            crate::use_window(),
+            leptos::ev::languagechange,
+            move |_| {
                 set_locales.update(|locales| *locales = read_navigator_languages());
-            });
+            },
+            crate::UseEventListenerOptions::default().passive(true),
+        );
 
         locales.into()
     }

--- a/src/use_media_query.rs
+++ b/src/use_media_query.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "ssr", allow(unused_variables, unused_imports, dead_code))]
 
-use crate::use_event_listener;
+use crate::{UseEventListenerOptions, use_event_listener_with_options};
 use cfg_if::cfg_if;
 use leptos::ev::change;
 use leptos::prelude::*;
@@ -78,10 +78,11 @@ pub fn use_media_query(query: impl Into<Signal<String>>) -> Signal<bool> {
 
                     let listener = Rc::clone(&*listener.borrow());
 
-                    remove_listener.replace(Some(Box::new(use_event_listener(
+                    remove_listener.replace(Some(Box::new(use_event_listener_with_options(
                         media_query.clone(),
                         change,
                         move |e| listener(e),
+                        UseEventListenerOptions::default().passive(true),
                     ))));
                 } else {
                     set_matches.set(false);

--- a/src/use_mouse_in_element.rs
+++ b/src/use_mouse_in_element.rs
@@ -113,7 +113,7 @@ where
 
     #[cfg(not(feature = "ssr"))]
     {
-        use crate::{sendwrap_fn, use_event_listener};
+        use crate::{UseEventListenerOptions, sendwrap_fn, use_event_listener_with_options};
         use leptos::ev::mouseleave;
 
         let target = target.into_element_maybe_signal();
@@ -159,7 +159,12 @@ where
 
         stop = sendwrap_fn!(move || effect.stop());
 
-        let _ = use_event_listener(document(), mouseleave, move |_| set_outside.set(true));
+        let _ = use_event_listener_with_options(
+            document(),
+            mouseleave,
+            move |_| set_outside.set(true),
+            UseEventListenerOptions::default().passive(true),
+        );
     }
 
     UseMouseInElementReturn {

--- a/src/use_permission.rs
+++ b/src/use_permission.rs
@@ -32,7 +32,7 @@ pub fn use_permission(permission_name: &str) -> Signal<PermissionState> {
 
     #[cfg(not(feature = "ssr"))]
     {
-        use crate::use_event_listener;
+        use crate::{UseEventListenerOptions, use_event_listener_with_options};
         use std::cell::RefCell;
         use std::rc::Rc;
 
@@ -53,10 +53,15 @@ pub fn use_permission(permission_name: &str) -> Signal<PermissionState> {
 
             async move {
                 if let Ok(status) = query_permission(permission_name).await {
-                    let _ = use_event_listener(status.clone(), leptos::ev::change, {
-                        let on_change = on_change.clone();
-                        move |_| on_change()
-                    });
+                    let _ = use_event_listener_with_options(
+                        status.clone(),
+                        leptos::ev::change,
+                        {
+                            let on_change = on_change.clone();
+                            move |_| on_change()
+                        },
+                        UseEventListenerOptions::default().passive(true),
+                    );
                     permission_status.replace(Some(status));
                     on_change();
                 } else {

--- a/src/use_window_focus.rs
+++ b/src/use_window_focus.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "ssr", allow(unused_variables, unused_imports))]
 
-use crate::use_event_listener;
+use crate::{UseEventListenerOptions, use_event_listener_with_options};
 use cfg_if::cfg_if;
 use leptos::ev::{blur, focus};
 use leptos::prelude::*;
@@ -41,8 +41,19 @@ pub fn use_window_focus() -> Signal<bool> {
     let (focused, set_focused) = signal(initial_focus);
 
     cfg_if! { if #[cfg(not(feature = "ssr"))] {
-        let _ = use_event_listener(window(), blur, move |_| set_focused.set(false));
-        let _ = use_event_listener(window(), focus, move |_| set_focused.set(true));
+        let listener_options = UseEventListenerOptions::default().passive(true);
+        let _ = use_event_listener_with_options(
+            window(),
+            blur,
+            move |_| set_focused.set(false),
+            listener_options,
+        );
+        let _ = use_event_listener_with_options(
+            window(),
+            focus,
+            move |_| set_focused.set(true),
+            listener_options,
+        );
     }}
 
     focused.into()


### PR DESCRIPTION
Sets passive listener options in hooks that do not call `prevent_default`. `use_draggable` stays non-passive when that option is enabled.

Closes #273.
