### PR TITLE
fix(use_web_lock): track web-sys 0.3.104

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2"
 unic-langid = { version = "0.9", optional = true }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "^0.3.89", optional = true }
+web-sys = { version = "^0.3.104", optional = true }
 
 [dev-dependencies]
 codee = { version = "0.3", features = [

--- a/src/use_web_lock.rs
+++ b/src/use_web_lock.rs
@@ -100,14 +100,11 @@ where
         }) as Box<dyn FnOnce(web_sys::Lock) -> _>)
         .into_js_value();
 
-        let lock_promise = window()
-            .navigator()
-            .locks()
-            .request_with_options_and_callback(
-                name,
-                &options.to_web_sys(),
-                handler.unchecked_ref(),
-            );
+        let lock_promise = window().navigator().locks().request_with_options(
+            name,
+            &options.to_web_sys(),
+            handler.unchecked_ref(),
+        );
 
         js_fut!(lock_promise)
             .await


### PR DESCRIPTION
Closes #325 

LockManager renames cause breakage.

web-sys 0.3.104 renamed the Web Locks bindings, dropping the overload disambiguator now that the callback is a typed js_sys::Function rather than an untyped one:

    request_with_callback              -> request
    request_with_options_and_callback  -> request_with_options

Both spellings are gated behind --cfg=web_sys_unstable_apis, and unstable web-sys APIs are exempt from semver, so this landed in a patch release and broke every downstream build that resolved 0.3.104:

    error[E0599]: no method named `request_with_options_and_callback`
    found for struct `LockManager` in the current scope

Rename the call site and raise the web-sys floor to ^0.3.104. The floor bump is the part that actually fixes it — under the old ^0.3.89 Cargo can still resolve 0.3.103, where `request_with_options` does not exist, which would leave the crate broken in the other direction.