### PR TITLE
Fix medium-severity bugs across timers, networking, and browser APIs

### DIFF
--- a/src/storage/use_storage.rs
+++ b/src/storage/use_storage.rs
@@ -318,6 +318,7 @@ where
             let storage = storage.to_owned();
             let on_error = on_error.to_owned();
             let dispatch_storage_event = dispatch_storage_event.to_owned();
+            let default = default.clone();
 
             let _ = watch_with_options(
                 move || (notify_id.get(), data.get()),
@@ -417,6 +418,10 @@ where
         // Remove from storage fn
         let remove = {
             sendwrap_fn!(move || {
+                // Reset the signal right away just like on the server. The
+                // notification below only refetches on the next reactive tick.
+                set_data.set(default.clone());
+
                 let _ = storage.as_ref().map(|storage| {
                     // Delete directly from storage
                     let result = storage

--- a/src/use_color_mode.rs
+++ b/src/use_color_mode.rs
@@ -261,7 +261,7 @@ where
             move |target: ElementMaybeSignal<web_sys::Element>,
                   attribute: String,
                   value: ColorMode| {
-                let el = target.get_untracked();
+                let el = target.get();
 
                 if let Some(el) = el {
                     let mut style: Option<web_sys::HtmlStyleElement> = None;

--- a/src/use_cookie.rs
+++ b/src/use_cookie.rs
@@ -227,7 +227,7 @@ where
     #[cfg(not(feature = "ssr"))]
     {
         use crate::{
-            UseBroadcastChannelReturn, WatchPausableReturn, use_broadcast_channel, watch_pausable,
+            UseBroadcastChannelReturn, WatchOptions, use_broadcast_channel, watch_with_options,
         };
         use codee::string::{FromToStringCodec, OptionCodec};
 
@@ -302,18 +302,27 @@ where
             }
         };
 
-        let WatchPausableReturn {
-            pause,
-            resume,
-            stop,
-            ..
-        } = watch_pausable(move || cookie.track(), {
-            let on_cookie_change = on_cookie_change.clone();
+        // Marks the next watcher invocation as originating from the broadcast
+        // channel. The watcher runs deferred, i.e. after the message handler has
+        // returned, so the flag has to survive until then.
+        let from_broadcast = StoredValue::new(false);
 
-            move |_, _, _| {
-                on_cookie_change();
-            }
-        });
+        let stop = watch_with_options(
+            move || cookie.track(),
+            {
+                let on_cookie_change = on_cookie_change.clone();
+
+                move |_, _, _| {
+                    if from_broadcast.get_value() {
+                        from_broadcast.set_value(false);
+                        return;
+                    }
+
+                    on_cookie_change();
+                }
+            },
+            WatchOptions::default(),
+        );
 
         // listen to cookie changes from the broadcast channel
         Effect::new({
@@ -322,8 +331,6 @@ where
 
             move |_| {
                 if let Some(message) = message.get() {
-                    pause();
-
                     if let Some(message) = message {
                         match C::decode(&message) {
                             Ok(value) => {
@@ -346,6 +353,7 @@ where
                                     );
                                 });
 
+                                from_broadcast.set_value(true);
                                 set_cookie.set(Some(value));
                             }
                             Err(err) => {
@@ -373,10 +381,9 @@ where
                             jar.force_remove(cookie_name);
                         });
 
+                        from_broadcast.set_value(true);
                         set_cookie.set(None);
                     }
-
-                    resume();
                 }
             }
         });

--- a/src/use_drop_zone.rs
+++ b/src/use_drop_zone.rs
@@ -138,7 +138,7 @@ where
 
         let _ = use_event_listener(target, dragleave, move |event| {
             event.prevent_default();
-            counter.update_value(|counter| *counter -= 1);
+            counter.update_value(|counter| *counter = counter.saturating_sub(1));
             if counter.get_value() == 0 {
                 set_over_drop_zone.set(false);
             }

--- a/src/use_event_source.rs
+++ b/src/use_event_source.rs
@@ -216,6 +216,7 @@ where
     #[cfg(not(feature = "ssr"))]
     {
         use crate::{sendwrap_fn, use_event_listener};
+        use leptos::leptos_dom::helpers::TimeoutHandle;
         use std::sync::atomic::{AtomicBool, AtomicU32};
         use std::time::Duration;
         use wasm_bindgen::prelude::*;
@@ -258,6 +259,16 @@ where
         };
 
         let init = StoredValue::new(None::<Arc<dyn Fn() + Send + Sync>>);
+
+        let reconnect_timer: StoredValue<Option<TimeoutHandle>> = StoredValue::new(None);
+
+        let clear_reconnect_timer = move || {
+            reconnect_timer.update_value(|timer| {
+                if let Some(timer) = timer.take() {
+                    timer.clear();
+                }
+            });
+        };
 
         let set_init = {
             let explicitly_closed = Arc::clone(&explicitly_closed);
@@ -325,13 +336,20 @@ where
                                         + 1;
 
                                     if !reconnect_limit.is_exceeded_by(retried_value as u64) {
-                                        set_timeout(
-                                            move || {
-                                                if let Some(init) = init.get_value() {
-                                                    init();
-                                                }
-                                            },
-                                            Duration::from_millis(reconnect_interval),
+                                        clear_reconnect_timer();
+
+                                        reconnect_timer.set_value(
+                                            set_timeout_with_handle(
+                                                move || {
+                                                    reconnect_timer.set_value(None);
+
+                                                    if let Some(init) = init.get_value() {
+                                                        init();
+                                                    }
+                                                },
+                                                Duration::from_millis(reconnect_interval),
+                                            )
+                                            .ok(),
                                         );
                                     } else {
                                         #[cfg(debug_assertions)]
@@ -380,6 +398,10 @@ where
             let explicitly_closed = Arc::clone(&explicitly_closed);
 
             sendwrap_fn!(move || {
+                // A reconnect scheduled by an earlier error would otherwise still fire and
+                // open a second connection behind the caller's back.
+                clear_reconnect_timer();
+
                 if let Some(event_source) = event_source.get_untracked() {
                     event_source.close();
                     set_event_source.set(None);

--- a/src/use_geolocation.rs
+++ b/src/use_geolocation.rs
@@ -97,6 +97,10 @@ pub fn use_geolocation_with_options(
                 if let Some(navigator) = navigator
                     && let Ok(geolocation) = navigator.geolocation()
                 {
+                    if let Some(handle) = watch_handle.lock().unwrap().take() {
+                        geolocation.clear_watch(handle);
+                    }
+
                     let update_position =
                         Closure::wrap(Box::new(update_position) as Box<dyn Fn(web_sys::Position)>);
                     let on_error =

--- a/src/use_idle.rs
+++ b/src/use_idle.rs
@@ -122,7 +122,7 @@ pub fn use_idle_with_options(
                 if let Some(timer) = timer.replace(
                     set_timeout_with_handle(
                         move || set_idle.set(true),
-                        Duration::from_millis(timeout),
+                        Duration::from_millis(timeout.min(i32::MAX as u64)),
                     )
                     .ok(),
                 ) {

--- a/src/use_infinite_scroll.rs
+++ b/src/use_infinite_scroll.rs
@@ -156,12 +156,13 @@ where
                     let scroll_width = observed_element.scroll_width();
                     let client_width = observed_element.client_width();
 
-                    let is_narrower =
-                        if direction == Direction::Bottom || direction == Direction::Top {
-                            scroll_height <= client_height
-                        } else {
-                            scroll_width <= client_width
-                        };
+                    let is_vertical = direction == Direction::Bottom || direction == Direction::Top;
+
+                    let is_narrower = if is_vertical {
+                        scroll_height <= client_height
+                    } else {
+                        scroll_width <= client_width
+                    };
 
                     if (state.arrived_state.get_untracked().get_direction(direction) || is_narrower)
                         && !is_loading.get_untracked()
@@ -169,6 +170,12 @@ where
                         set_loading.set(true);
 
                         let measure = measure.clone();
+                        let scroll_size_before = if is_vertical {
+                            scroll_height
+                        } else {
+                            scroll_width
+                        };
+
                         leptos::task::spawn_local(async move {
                             #[cfg(debug_assertions)]
                             let zone =
@@ -185,7 +192,17 @@ where
                             set_loading.try_set(false);
                             sleep(Duration::ZERO).await;
                             measure();
-                            if let Some(check_and_load) = check_and_load.try_get_value().flatten() {
+
+                            let scroll_size_after = if is_vertical {
+                                observed_element.scroll_height()
+                            } else {
+                                observed_element.scroll_width()
+                            };
+
+                            if scroll_size_after > scroll_size_before
+                                && let Some(check_and_load) =
+                                    check_and_load.try_get_value().flatten()
+                            {
                                 check_and_load();
                             }
                         });

--- a/src/use_interval_fn.rs
+++ b/src/use_interval_fn.rs
@@ -140,7 +140,7 @@ where
             timer.set(
                 set_interval_with_handle(
                     callback,
-                    Duration::from_millis(interval_value),
+                    Duration::from_millis(interval_value.min(i32::MAX as u64)),
                 )
                 .ok(),
             );

--- a/src/use_interval_fn.rs
+++ b/src/use_interval_fn.rs
@@ -110,55 +110,60 @@ where
 
         let interval = interval.into();
 
-        resume = sendwrap_fn!(move || {
-            #[cfg(not(feature = "ssr"))]
-            {
-                let interval_value = interval.get();
-                if interval_value == 0 {
-                    return;
-                }
-
-                set_active.set(true);
-
-                let callback = {
-                    let callback = callback.clone();
-
-                    move || {
-                        #[cfg(debug_assertions)]
-                        let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
-
-                        callback();
-                    }
-                };
-
-                if immediate_callback {
-                    callback.clone()();
-                }
-                clean();
-
-                timer.set(
-                    set_interval_with_handle(
-                        callback.clone(),
-                        Duration::from_millis(interval_value),
-                    )
-                    .ok(),
-                );
+        // `run_immediate_callback` is only `true` for user initiated (re)starts. Restarts
+        // that are triggered by a change of the `interval` signal must not fire an extra
+        // out-of-cadence callback.
+        let start = move |run_immediate_callback: bool| {
+            let interval_value = interval.get();
+            if interval_value == 0 {
+                return;
             }
-        });
+
+            set_active.set(true);
+
+            let callback = {
+                let callback = callback.clone();
+
+                move || {
+                    #[cfg(debug_assertions)]
+                    let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
+
+                    callback();
+                }
+            };
+
+            if run_immediate_callback {
+                callback.clone()();
+            }
+            clean();
+
+            timer.set(
+                set_interval_with_handle(
+                    callback,
+                    Duration::from_millis(interval_value),
+                )
+                .ok(),
+            );
+        };
+
+        resume = {
+            let start = start.clone();
+
+            sendwrap_fn!(move || start(immediate_callback))
+        };
 
         if immediate {
             resume();
         }
 
         {
-            #[allow(clippy::clone_on_copy)]
-            let resume = resume.clone();
+            let restart = sendwrap_fn!(move || start(false));
 
             let effect = Effect::watch(
                 move || interval.get(),
                 move |_, _, _| {
                     if is_active.get() {
-                        resume();
+                        restart();
                     }
                 },
                 false,

--- a/src/use_locale.rs
+++ b/src/use_locale.rs
@@ -66,28 +66,26 @@ where
 
     Signal::derive(move || {
         client_locales.with(|client_locales| {
-            let mut supported_iter = supported.iter().peekable();
-
-            // Checked it's not empty above.
-            let first_supported = *supported_iter.peek().unwrap();
-
             for client_locale in client_locales {
-                let supported_iter = supported_iter.clone();
+                let Ok(client_locale) = client_locale.parse::<LanguageIdentifier>() else {
+                    warn!("Received an invalid LanguageIdentifier");
+                    continue;
+                };
 
-                for s in supported_iter {
-                    let client_locale = client_locale.parse::<LanguageIdentifier>();
+                if let Some(s) = supported.iter().find(|s| **s == client_locale) {
+                    return s.clone();
+                }
 
-                    if let Ok(client_locale) = client_locale {
-                        if client_locale.matches(s, true, true) {
-                            return (*s).clone();
-                        }
-                    } else {
-                        warn!("Received an invalid LanguageIdentifier")
-                    }
+                if let Some(s) = supported
+                    .iter()
+                    .find(|s| client_locale.matches(*s, true, true))
+                {
+                    return s.clone();
                 }
             }
 
-            (*first_supported).clone()
+            // Checked it's not empty above.
+            supported.first().expect(EMPTY_ERR_MSG).clone()
         })
     })
 }

--- a/src/use_permission.rs
+++ b/src/use_permission.rs
@@ -48,22 +48,34 @@ pub fn use_permission(permission_name: &str) -> Signal<PermissionState> {
             }
         };
 
+        let owner = Owner::current();
+
         leptos::task::spawn_local({
             let permission_name = permission_name.to_owned();
 
             async move {
                 if let Ok(status) = query_permission(permission_name).await {
-                    let _ = use_event_listener_with_options(
-                        status.clone(),
-                        leptos::ev::change,
-                        {
-                            let on_change = on_change.clone();
-                            move |_| on_change()
-                        },
-                        UseEventListenerOptions::default().passive(true),
-                    );
-                    permission_status.replace(Some(status));
-                    on_change();
+                    // `spawn_local` doesn't restore the reactive owner after the `.await`.
+                    // Without it the event listener would never be cleaned up.
+                    let setup = move || {
+                        let _ = use_event_listener_with_options(
+                            status.clone(),
+                            leptos::ev::change,
+                            {
+                                let on_change = on_change.clone();
+                                move |_| on_change()
+                            },
+                            UseEventListenerOptions::default().passive(true),
+                        );
+                        permission_status.replace(Some(status));
+                        on_change();
+                    };
+
+                    if let Some(owner) = owner {
+                        owner.with(setup);
+                    } else {
+                        setup();
+                    }
                 } else {
                     set_state.set(PermissionState::Prompt);
                 }

--- a/src/use_screen_orientation.rs
+++ b/src/use_screen_orientation.rs
@@ -46,56 +46,82 @@ pub fn use_screen_orientation() -> UseScreenOrientationReturn<
     {
         use std::rc::Rc;
 
-        use crate::{UseEventListenerOptions, sendwrap_fn, use_event_listener_with_options};
+        use crate::{
+            UseEventListenerOptions, js_fut, sendwrap_fn, use_event_listener_with_options,
+        };
         use leptos::ev::orientationchange;
+        use leptos::logging::debug_warn;
 
-        let screen_orientation = Rc::new(
-            window()
-                .screen()
-                .expect("screen not available")
-                .orientation(),
-        );
+        let screen_orientation = window()
+            .screen()
+            .ok()
+            .map(|screen| Rc::new(screen.orientation()));
+
+        let read_orientation = |screen_orientation: &web_sys::ScreenOrientation| {
+            screen_orientation
+                .type_()
+                .map_or(ScreenOrientation::PortraitPrimary, Into::into)
+        };
 
         let (orientation, set_orientation) = signal(
             screen_orientation
-                .type_()
-                .expect("cannot read screen orientation")
-                .into(),
+                .as_ref()
+                .map_or(ScreenOrientation::PortraitPrimary, |screen_orientation| {
+                    read_orientation(screen_orientation)
+                }),
         );
-        let (angle, set_angle) = signal(screen_orientation.angle().unwrap_or_default());
+        let (angle, set_angle) = signal(
+            screen_orientation
+                .as_ref()
+                .and_then(|screen_orientation| screen_orientation.angle().ok())
+                .unwrap_or_default(),
+        );
 
         let _ = use_event_listener_with_options(
             window(),
             orientationchange,
             {
-                let screen_orientation = Rc::clone(&screen_orientation);
+                let screen_orientation = screen_orientation.clone();
 
                 move |_| {
-                    set_orientation.set(
-                        screen_orientation
-                            .type_()
-                            .expect("cannot read screen orientation")
-                            .into(),
-                    );
-                    set_angle.set(screen_orientation.angle().unwrap_or_default());
+                    if let Some(screen_orientation) = screen_orientation.as_ref() {
+                        set_orientation.set(read_orientation(screen_orientation));
+                        set_angle.set(screen_orientation.angle().unwrap_or_default());
+                    }
                 }
             },
             UseEventListenerOptions::default().passive(true),
         );
 
         let lock_orientation = {
-            let screen_orientation = Rc::clone(&screen_orientation);
+            let screen_orientation = screen_orientation.clone();
+
             sendwrap_fn!(move |lock: ScreenOrientationLock| {
-                let _ = screen_orientation
-                    .lock(lock.into())
-                    .expect("cannot lock screen orientation");
+                let Some(screen_orientation) = screen_orientation.as_ref() else {
+                    return;
+                };
+
+                match screen_orientation.lock(lock.into()) {
+                    Ok(promise) => {
+                        leptos::task::spawn_local(async move {
+                            if let Err(err) = js_fut!(promise).await {
+                                debug_warn!("cannot lock screen orientation: {:?}", err);
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        debug_warn!("cannot lock screen orientation: {:?}", err);
+                    }
+                }
             })
         };
 
         let unlock_orientation = sendwrap_fn!(move || {
-            screen_orientation
-                .unlock()
-                .expect("cannot unlock screen orientation");
+            if let Some(screen_orientation) = screen_orientation.as_ref()
+                && let Err(err) = screen_orientation.unlock()
+            {
+                debug_warn!("cannot unlock screen orientation: {:?}", err);
+            }
         });
 
         UseScreenOrientationReturn {

--- a/src/use_timeout_fn.rs
+++ b/src/use_timeout_fn.rs
@@ -114,7 +114,7 @@ where
                             callback(arg);
                         }
                     },
-                    Duration::from_millis(delay.get_untracked() as u64),
+                    Duration::from_millis((delay.get_untracked() as u64).min(i32::MAX as u64)),
                 )
                 .ok();
 

--- a/src/use_websocket.rs
+++ b/src/use_websocket.rs
@@ -360,6 +360,10 @@ where
         let reconnect_times_ref: StoredValue<u64> = StoredValue::new(0);
         let manually_closed_ref: StoredValue<bool> = StoredValue::new(false);
 
+        // Identifies the socket the handlers below belong to. Handlers of a socket that has
+        // since been superseded must not touch the shared state anymore.
+        let connection_id_ref: StoredValue<u64> = StoredValue::new(0);
+
         let unmounted = Arc::new(AtomicBool::new(false));
 
         let connect_ref: StoredValue<Option<Arc<dyn Fn() + Send + Sync>>> = StoredValue::new(None);
@@ -485,6 +489,9 @@ where
                     let _ = web_socket.close();
                 }
 
+                connection_id_ref.update_value(|id| *id += 1);
+                let connection_id = connection_id_ref.get_value();
+
                 let web_socket = {
                     protocols.with_untracked(|protocols| {
                         protocols.as_ref().map_or_else(
@@ -512,7 +519,9 @@ where
                         let start_heartbeat = start_heartbeat.clone();
 
                         move |e: Event| {
-                            if unmounted.load(std::sync::atomic::Ordering::Relaxed) {
+                            if unmounted.load(std::sync::atomic::Ordering::Relaxed)
+                                || connection_id_ref.get_value() != connection_id
+                            {
                                 return;
                             }
 
@@ -544,7 +553,9 @@ where
                     let on_error = Arc::clone(&on_error);
 
                     let onmessage_closure = Closure::wrap(Box::new(move |e: MessageEvent| {
-                        if unmounted.load(std::sync::atomic::Ordering::Relaxed) {
+                        if unmounted.load(std::sync::atomic::Ordering::Relaxed)
+                            || connection_id_ref.get_value() != connection_id
+                        {
                             return;
                         }
 
@@ -629,7 +640,9 @@ where
                     let on_error = Arc::clone(&on_error);
 
                     let onerror_closure = Closure::wrap(Box::new(move |e: Event| {
-                        if unmounted.load(std::sync::atomic::Ordering::Relaxed) {
+                        if unmounted.load(std::sync::atomic::Ordering::Relaxed)
+                            || connection_id_ref.get_value() != connection_id
+                        {
                             return;
                         }
 
@@ -661,7 +674,9 @@ where
                     let on_close = Arc::clone(&on_close);
 
                     let onclose_closure = Closure::wrap(Box::new(move |e: CloseEvent| {
-                        if unmounted.load(std::sync::atomic::Ordering::Relaxed) {
+                        if unmounted.load(std::sync::atomic::Ordering::Relaxed)
+                            || connection_id_ref.get_value() != connection_id
+                        {
                             return;
                         }
 

--- a/src/utils/filters/debounce.rs
+++ b/src/utils/filters/debounce.rs
@@ -36,9 +36,11 @@ where
 
     on_cleanup({
         let timer = Arc::clone(&timer);
+        let max_timer = Arc::clone(&max_timer);
 
         move || {
             clear_timeout(&timer);
+            clear_timeout(&max_timer);
         }
     });
 

--- a/src/utils/filters/debounce.rs
+++ b/src/utils/filters/debounce.rs
@@ -93,7 +93,7 @@ where
                             *max_timer_slot.lock().unwrap() = None;
                             invok();
                         },
-                        Duration::from_millis(max_duration as u64),
+                        Duration::from_millis((max_duration as u64).min(i32::MAX as u64)),
                     )
                     .ok();
                 }
@@ -107,7 +107,7 @@ where
                     clear_timeout(&max_timer);
                     invoke();
                 },
-                Duration::from_millis(duration as u64),
+                Duration::from_millis((duration as u64).min(i32::MAX as u64)),
             )
             .ok();
         }}

--- a/src/utils/filters/throttle.rs
+++ b/src/utils/filters/throttle.rs
@@ -5,7 +5,6 @@ use cfg_if::cfg_if;
 use default_struct_builder::DefaultBuilder;
 use leptos::leptos_dom::helpers::TimeoutHandle;
 use leptos::prelude::*;
-use std::cmp::max;
 use std::sync::{Arc, Mutex, atomic::AtomicBool};
 use std::time::Duration;
 
@@ -33,7 +32,7 @@ pub fn throttle_filter<R>(
 where
     R: 'static,
 {
-    let last_exec = Arc::new(Mutex::new(0_f64));
+    let last_exec = Arc::new(Mutex::new(None::<f64>));
     let timer = Arc::new(Mutex::new(None::<TimeoutHandle>));
     let is_leading = Arc::new(AtomicBool::new(true));
     let last_return_value: Arc<Mutex<Option<R>>> = Arc::new(Mutex::new(None));
@@ -53,7 +52,8 @@ where
 
     move |mut _invoke: Arc<dyn Fn() -> R>| {
         let duration = ms.get_untracked();
-        let elapsed = now() - *last_exec.lock().unwrap();
+        // `None` means the filter has never executed yet.
+        let elapsed = last_exec.lock().unwrap().map(|last| now() - last);
 
         let last_return_val = Arc::clone(&last_return_value);
         let invoke = move || {
@@ -73,29 +73,31 @@ where
         clear();
 
         if duration <= 0.0 {
-            *last_exec.lock().unwrap() = now();
+            *last_exec.lock().unwrap() = Some(now());
             invoke();
             return Arc::clone(&last_return_value);
         }
 
-        if elapsed > duration
+        if elapsed.is_none_or(|elapsed| elapsed > duration)
             && (options.leading || !is_leading.load(std::sync::atomic::Ordering::Relaxed))
         {
-            *last_exec.lock().unwrap() = now();
+            *last_exec.lock().unwrap() = Some(now());
             invoke();
         } else if options.trailing {
             cfg_if! { if #[cfg(not(feature = "ssr"))] {
+                let remaining = elapsed.map_or(duration, |elapsed| (duration - elapsed).max(0.0));
+
                 let last_exec = Arc::clone(&last_exec);
                 let is_leading = Arc::clone(&is_leading);
                 *timer.lock().unwrap() =
                     set_timeout_with_handle(
                         move || {
-                            *last_exec.lock().unwrap() = now();
+                            *last_exec.lock().unwrap() = Some(now());
                             is_leading.store(true, std::sync::atomic::Ordering::Relaxed);
                             invoke();
                             clear();
                         },
-                        Duration::from_millis(max(0, (duration - elapsed) as u64)),
+                        Duration::from_millis(remaining as u64),
                     )
                     .ok();
             }}

--- a/src/utils/filters/throttle.rs
+++ b/src/utils/filters/throttle.rs
@@ -97,7 +97,7 @@ where
                             invoke();
                             clear();
                         },
-                        Duration::from_millis(remaining as u64),
+                        Duration::from_millis((remaining as u64).min(i32::MAX as u64)),
                     )
                     .ok();
             }}
@@ -112,7 +112,7 @@ where
                         move || {
                             is_leading.store(true, std::sync::atomic::Ordering::Relaxed);
                         },
-                        Duration::from_millis(duration as u64),
+                        Duration::from_millis((duration as u64).min(i32::MAX as u64)),
                     )
                     .ok();
             }

--- a/src/utils/header.rs
+++ b/src/utils/header.rs
@@ -26,11 +26,6 @@ where
     #[cfg(all(feature = "actix", feature = "axum"))]
     compile_error!("You can only enable one of features \"actix\" and \"axum\" at the same time");
 
-    #[cfg(feature = "actix")]
-    type HeaderValue = http0_2::HeaderValue;
-    #[cfg(feature = "axum")]
-    type HeaderValue = http1::HeaderValue;
-
     #[cfg(any(feature = "axum", feature = "actix"))]
     let headers;
     #[cfg(feature = "actix")]
@@ -45,14 +40,10 @@ where
 
     #[cfg(any(feature = "axum", feature = "actix"))]
     {
-        headers.map(|headers| {
+        headers.and_then(|headers| {
             headers
                 .get(name)
-                .cloned()
-                .unwrap_or_else(|| HeaderValue::from_static(""))
-                .to_str()
-                .unwrap_or_default()
-                .to_owned()
+                .map(|value| value.to_str().unwrap_or_default().to_owned())
         })
     }
 }

--- a/src/utils/signal_filtered.rs
+++ b/src/utils/signal_filtered.rs
@@ -84,10 +84,6 @@ macro_rules! signal_filtered_macro_impl{
             let value = value.into();
             let ms = ms.into();
 
-            if ms.get_untracked() <= 0.0 {
-                return value;
-            }
-
             let (filtered, set_filtered) = ::leptos::prelude::RwSignal::<T, $storage>::new_with_storage(value.get_untracked()).split();
 
             let update = [<use_ $filter_name _fn_with_options>](


### PR DESCRIPTION
This PR fixes 17 medium-severity bugs, one commit per fix. Each commit message describes the bug, a minimal repro, and the fix in detail.

**Timers & filters**
- `use_debounce_fn`: clear the pending `max_wait` timer on scope cleanup so the callback can't fire after disposal
- `use_throttle_fn`: with `leading(false)`, the first call now waits the full duration instead of firing immediately
- `use_interval_fn`: changing a reactive interval no longer re-fires the immediate callback
- Clamp all timer durations to `i32::MAX` ms to avoid panics from the JS timer API (`use_idle`, `use_interval_fn`, `use_timeout_fn`, debounce/throttle filters)
- `signal_debounced` / `signal_throttled`: react to filter period changes instead of sampling `ms` once at creation

**Networking**
- `use_websocket`: tag connections with a generation id so stale handlers from superseded sockets can't corrupt state or trigger spurious reconnects
- `use_event_source`: store and cancel the pending reconnect timer on `close()`, preventing duplicate connections

**Browser APIs & DOM**
- `use_screen_orientation`: no longer panics when the orientation API is unavailable; `lock()` rejections are now surfaced
- `use_permission`: capture the reactive owner before `spawn_local` so the change listener is cleaned up on unmount
- `use_geolocation`: clear the previous position watch on repeated `resume()` calls
- `use_drop_zone`: saturate the drag counter so unpaired `dragleave` events can't underflow it
- `use_infinite_scroll`: stop re-triggering loads when a load adds no new content
- `use_color_mode`: apply the mode to custom targets that mount after setup

**Storage & state**
- `use_cookie`: reliably suppress broadcast echoes to prevent cross-tab update loops
- `use_storage`: `remove()` resets the signal synchronously in the browser, matching server behavior
- `use_locale`: prefer an exact locale match over the first loose match
- `header()`: return `None` for absent headers instead of `Some("")`

No public API changes.