### PR TITLE
Fix/low severity bugs

### DIFF
--- a/src/core/datetime.rs
+++ b/src/core/datetime.rs
@@ -6,9 +6,11 @@ pub(crate) fn now() -> f64 {
     cfg_if! { if #[cfg(feature = "ssr")] {
         use std::time::{SystemTime, UNIX_EPOCH};
 
+        // If the system clock is at or before the Unix epoch we degrade to 0
+        // instead of panicking.
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_millis() as f64
     } else {
         js_sys::Date::now()

--- a/src/core/url.rs
+++ b/src/core/url.rs
@@ -1,14 +1,11 @@
 use leptos::prelude::*;
 
 #[cfg_attr(feature = "ssr", allow(dead_code))]
-fn get() -> web_sys::Url {
-    web_sys::Url::new(
-        &window()
-            .location()
-            .href()
-            .expect("Failed to get location.href from the browser"),
-    )
-    .expect("Failed to parse location.href from the browser")
+/// Returns `None` if `location.href` is inaccessible (for example in a sandboxed
+/// cross-origin iframe, where it throws a `SecurityError`) or cannot be parsed.
+fn get() -> Option<web_sys::Url> {
+    let href = window().location().href().ok()?;
+    web_sys::Url::new(&href).ok()
 }
 
 pub mod params {
@@ -21,7 +18,7 @@ pub mod params {
             None
         } else {
             use super::get as current_url;
-            current_url().search_params().get(k)
+            current_url()?.search_params().get(k)
         }}
     }
 }

--- a/src/storage/use_storage.rs
+++ b/src/storage/use_storage.rs
@@ -310,6 +310,11 @@ where
             }
         });
 
+        // Notify id as of hook setup. The watch below runs its first tick deferred, so a
+        // notification can race in before then. Comparing against this baseline lets that
+        // first tick recognize an external change instead of assuming there was none.
+        let initial_notify_id = notify_id.get_untracked();
+
         // Set item on internal (non-event) page changes to the data signal
         {
             let storage = storage.to_owned();
@@ -320,8 +325,9 @@ where
                 move || (notify_id.get(), data.get()),
                 move |(id, value), prev, _| {
                     // Skip setting storage on changes from external events. The ID will change on external events.
-                    let change_from_external_event =
-                        prev.map(|(prev_id, _)| *prev_id != *id).unwrap_or_default();
+                    let change_from_external_event = prev
+                        .map(|(prev_id, _)| *prev_id != *id)
+                        .unwrap_or_else(|| *id != initial_notify_id);
 
                     if change_from_external_event {
                         return;

--- a/src/storage/use_storage.rs
+++ b/src/storage/use_storage.rs
@@ -230,15 +230,12 @@ where
                     // Note: we cannot construct a full StorageEvent so we _must_ rely on a custom event
                     let custom = web_sys::CustomEventInit::new();
                     custom.set_detail(&JsValue::from_str(&key.get_untracked()));
-                    let result = window()
-                        .dispatch_event(
-                            &web_sys::CustomEvent::new_with_event_init_dict(
-                                INTERNAL_STORAGE_EVENT,
-                                &custom,
-                            )
-                            .expect("failed to create custom storage event"),
-                        )
-                        .map_err(UseStorageError::NotifyItemChangedFailed);
+                    let result = web_sys::CustomEvent::new_with_event_init_dict(
+                        INTERNAL_STORAGE_EVENT,
+                        &custom,
+                    )
+                    .and_then(|event| window().dispatch_event(&event))
+                    .map_err(UseStorageError::NotifyItemChangedFailed);
                     let _ = handle_error(&on_error, result);
                 })
             }

--- a/src/use_breakpoints.rs
+++ b/src/use_breakpoints.rs
@@ -230,7 +230,7 @@ where
         format!("(min-width: {min}px) and (max-width: {}.9px)", max - 1)
     }
 
-    /// Reactive check if `min_key` <= `[screen size]` <= `max_key`
+    /// Reactive check if `min_key` <= `[screen size]` < `max_key`
     pub fn between(&self, min_key: K, max_key: K) -> Signal<bool> {
         if let Some(min) = self.breakpoints.get(&min_key) {
             if let Some(max) = self.breakpoints.get(&max_key) {
@@ -243,7 +243,7 @@ where
         }
     }
 
-    /// Static check if `min_key` <= `[screen size]` <= `max_key`
+    /// Static check if `min_key` <= `[screen size]` < `max_key`
     pub fn is_between(&self, min_key: K, max_key: K) -> bool {
         if let Some(min) = self.breakpoints.get(&min_key) {
             if let Some(max) = self.breakpoints.get(&max_key) {

--- a/src/use_broadcast_channel.rs
+++ b/src/use_broadcast_channel.rs
@@ -159,18 +159,11 @@ where
                     );
 
                     let _ = use_event_listener_with_options(
-                        channel.clone(),
+                        channel,
                         messageerror,
                         move |event| {
                             error.set(Some(UseBroadcastChannelError::MessageEvent(event)));
                         },
-                        UseEventListenerOptions::default().passive(true),
-                    );
-
-                    let _ = use_event_listener_with_options(
-                        channel,
-                        leptos::ev::close,
-                        move |_| set_closed.set(true),
                         UseEventListenerOptions::default().passive(true),
                     );
                 }

--- a/src/use_draggable.rs
+++ b/src/use_draggable.rs
@@ -119,7 +119,7 @@ where
                 }
 
                 #[allow(clippy::unnecessary_cast)]
-                let position = Position {
+                let grab_offset = Position {
                     x: event.client_x() as f64 - x,
                     y: event.client_y() as f64 - y,
                 };
@@ -128,7 +128,7 @@ where
                 let zone = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
 
                 if !on_start(UseDraggableCallbackArgs {
-                    position,
+                    position: Position { x, y },
                     event: event.clone(),
                 }) {
                     #[cfg(debug_assertions)]
@@ -139,7 +139,7 @@ where
                 #[cfg(debug_assertions)]
                 drop(zone);
 
-                set_start_position.set(Some(position));
+                set_start_position.set(Some(grab_offset));
                 handle_event(event);
             }
         }

--- a/src/use_mouse_in_element.rs
+++ b/src/use_mouse_in_element.rs
@@ -142,8 +142,8 @@ where
                     set_outside.set(
                         width == 0.0
                             || height == 0.0
-                            || el_x <= 0.0
-                            || el_y <= 0.0
+                            || el_x < 0.0
+                            || el_y < 0.0
                             || el_x > width
                             || el_y > height,
                     );

--- a/src/watch_debounced.rs
+++ b/src/watch_debounced.rs
@@ -116,7 +116,7 @@ where
 pub struct WatchDebouncedOptions {
     /// If `immediate` is false, the `callback` will not run immediately but only after
     /// the first change is detected of any signal that is accessed in `deps`.
-    /// Defaults to `true`.
+    /// Defaults to `false`.
     immediate: bool,
 
     /// The maximum time allowed to be delayed before the callback invoked.

--- a/src/watch_throttled.rs
+++ b/src/watch_throttled.rs
@@ -119,7 +119,7 @@ where
 pub struct WatchThrottledOptions {
     /// If `immediate` is false, the `callback` will not run immediately but only after
     /// the first change is detected of any signal that is accessed in `deps`.
-    /// Defaults to `true`.
+    /// Defaults to `false`.
     immediate: bool,
 
     /// Invoke on the trailing edge of the timeout. Defaults to `true`.


### PR DESCRIPTION
A batch of small fixes: edge-case panics, contract inconsistencies, dead code, and doc corrections. No API changes.

### Panics removed

- **`core::datetime`** — server-side `now()` panicked when the system clock is at or before the Unix epoch (misconfigured containers, manual clock changes). It now returns `0.0`.
- **`core::url`** — URL-param lookup panicked when reading `location.href` throws (e.g. a sandboxed cross-origin iframe without `allow-same-origin`), which took down `use_color_mode` at setup. It now returns `None`, matching the server-side behavior.
- **`use_storage`** — a failed custom-event construction in the write path panicked inside a microtask instead of going through `on_error` like every other failure in the module. It's now routed through `NotifyItemChangedFailed`.

### Behavior fixes

- **`use_draggable`** — `on_start` received the pointer's grab offset inside the element instead of the documented element position; it now reports the same quantity as `on_move`/`on_end`. Drag math and cancel-on-`false` are unchanged.
- **`use_mouse_in_element`** — a pointer exactly on the left/top edge was classified outside while the right/bottom edge counted as inside; all four edges now classify as inside.
- **`use_storage`** — a storage notification racing in before the mirror watch's first tick was misclassified as an internal change, causing a redundant same-value write-back. The first tick now compares against a setup-time baseline id.

### Dead code

- **`use_broadcast_channel`** — removed a listener for a `close` event that the BroadcastChannel API never fires (the spec only defines `message`/`messageerror`; `is_closed` is already set synchronously by the hook's own `close()`).

### Docs

- **`use_breakpoints`** — `between()`/`is_between()` documented an inclusive upper bound; the generated media query is intentionally exclusive (`[min, max)`), and the docs now say so.
- **`watch_debounced` / `watch_throttled`** — `immediate` was documented as defaulting to `true`; the actual default is `false`. Docs corrected, defaults unchanged.